### PR TITLE
Alias /components to primer-react-dev for now

### DIFF
--- a/rules.json
+++ b/rules.json
@@ -1,5 +1,5 @@
 {
   "rules": [
-    {"pathname": "/components/**", "dest": "primer-react.now.sh"}
+    {"pathname": "/components/**", "dest": "primer-react-dev.now.sh"}
   ]
 }


### PR DESCRIPTION
The current deployment at `primer-react.now.sh` doesn't work well when served from `primer.style`. For now, we can use the `primer-react-dev` alias to point it at the most recent deployment of https://github.com/primer/primer-react/pull/238.