### PR TITLE
Switch /components path alias back to primer-react

### DIFF
--- a/rules.json
+++ b/rules.json
@@ -1,5 +1,5 @@
 {
   "rules": [
-    {"pathname": "/components/**", "dest": "primer-react-dev.now.sh"}
+    {"pathname": "/components/**", "dest": "primer-react.now.sh"}
   ]
 }


### PR DESCRIPTION
We can merge and then re-deploy this once we've deployed https://github.com/primer/primer-react/pull/238 to `primer-react.now.sh`.