### PR TITLE
Revert theme changes

### DIFF
--- a/pages/_app.js
+++ b/pages/_app.js
@@ -4,13 +4,13 @@ import {ThemeProvider} from 'emotion-theming'
 import theme from '../src/theme.js'
 
 const Page = props => (
-  <ThemeProvider theme={theme}>
-    <BaseStyles>
+  <BaseStyles>
+    <ThemeProvider theme={theme}>
       <Box bg='black' color='blue.2'>
         {props.children}
       </Box>
-    </BaseStyles>
-  </ThemeProvider>
+    </ThemeProvider>
+  </BaseStyles>
 )
 
 export default Page

--- a/src/theme.js
+++ b/src/theme.js
@@ -3,7 +3,6 @@ import primitives from 'primer-primitives'
 const theme = {
   colors: primitives.colors,
   fontSizes: primitives.fontSizes,
-  space: primitives.space.space
 }
 
 export default theme

--- a/src/theme.js
+++ b/src/theme.js
@@ -1,6 +1,9 @@
-import {theme} from '@primer/components'
+import primitives from 'primer-primitives'
 
-export default {
-  ...theme,
-  space: theme.space.map(n => n * 2)
+const theme = {
+  colors: primitives.colors,
+  fontSizes: primitives.fontSizes,
+  space: primitives.space.space
 }
+
+export default theme


### PR DESCRIPTION
In #31 I tried pulling in the @primer/components theme, but since the site had already been built assuming the styled-system defaults were being used, it created too many (spacing, etc) bugs. I've reverted that for now. We can add theme values from @primer/components as needed in the future if we'd like.

I also removed the `space` key from the theme object because that was returning null, so that was just defaulting to the styled-system defaults anyways (there is no primitives.space.space key).

I  moved the `<BaseStyles>` component to be above the theme provider, for some reason when I changed the theme back it broke the default font, and this was the fix. 


The spacing here still feels a little tight, @broccolini do you remember if this is what it was like before? There aren't any top/bottom margin properties set on either of the elements so maybe this one just got missed.
This happens below 367px:
![image](https://user-images.githubusercontent.com/8960591/46425281-131e3e80-c6f0-11e8-9643-3ed7f2a00e3f.png)

