### PR TITLE
Dry up some stuff, add styled Octicon component

### DIFF
--- a/src/Octicon.js
+++ b/src/Octicon.js
@@ -1,0 +1,8 @@
+import Octicon from '@githubprimer/octicons-react'
+import styled from 'react-emotion'
+import {color, space} from 'styled-system'
+
+export default styled(Octicon)`
+  ${color};
+  ${space};
+`

--- a/src/OpenSource.js
+++ b/src/OpenSource.js
@@ -1,6 +1,7 @@
 import React from 'react'
 import {Box, Heading, Text} from '@primer/components'
-import Octicon, {Octoface, MarkGithub} from '@githubprimer/octicons-react'
+import {Octoface, MarkGithub} from '@githubprimer/octicons-react'
+import Octicon from './Octicon'
 import ButtonFillDark from './ButtonFillDark'
 import TwitterIcon from './TwitterIcon'
 import SpectrumIcon from './SpectrumIcon'
@@ -19,7 +20,7 @@ export default function OpenSource() {
             Primer is open-sourced on GitHub. Contributions and feedback are welcome!
           </Text>
           <ButtonFillDark mr={2} href="https://github.com/primer">
-            <Octicon color="blue.2" icon={MarkGithub} size={20} verticalAlign="text-bottom" className="mr-2" />
+            <FooterOcticon color="inherit" icon={MarkGithub} verticalAlign="text-bottom" />
             Contribute on GitHub
           </ButtonFillDark>
         </IndexGrid.Item>
@@ -27,18 +28,18 @@ export default function OpenSource() {
           <Heading lineHeight="1.25" color="black" mb={3} fontSize={7} fontWeight="bold">
             Keep in touch
           </Heading>
-          <LinkDark pt={1} fontSize={2} mb={3} className="d-block" href="https://twitter.com/githubprimer">
-            <Octicon color="blue.2" icon={TwitterIcon} size={20} verticalAlign="top" className="mr-2" />
+          <FooterLink href="https://twitter.com/githubprimer">
+            <FooterOcticon icon={TwitterIcon} verticalAlign="top" />
             Follow us on Twitter
-          </LinkDark>
-          <LinkDark fontSize={2} mb={3} className="d-block" href="https://spectrum.chat/primer">
-            <Octicon color="blue.2" icon={SpectrumIcon} size={20} verticalAlign="top" className="mr-2" />
+          </FooterLink>
+          <FooterLink href="https://spectrum.chat/primer">
+            <FooterOcticon icon={SpectrumIcon} verticalAlign="top" />
             Chat with us in Spectrum
-          </LinkDark>
-          <LinkDark fontSize={2} mb={3} className="d-block" href="https://github.com/primer/primer/issues/new/choose">
-            <Octicon color="blue.2" icon={Octoface} size={20} verticalAlign="text-top" className="mr-2" />
+          </FooterLink>
+          <FooterLink href="https://github.com/primer/primer/issues/new/choose">
+            <FooterOcticon icon={Octoface} verticalAlign="text-top" />
             Share feedback on GitHub
-          </LinkDark>
+          </FooterLink>
         </IndexGrid.Item>
       </IndexGrid>
       <Box color="black" px={4} className="container-xl mx-auto">
@@ -55,4 +56,12 @@ export default function OpenSource() {
       </Box>
     </Box>
   )
+}
+
+function FooterOcticon(props) {
+  return <Octicon mr={2} color="black" size={20} {...props} />
+}
+
+function FooterLink(props) {
+  return <LinkDark fontSize={2} mb={3} css={{display: 'block'}} {...props} />
 }

--- a/src/PrimerCSS.js
+++ b/src/PrimerCSS.js
@@ -1,10 +1,30 @@
 import React from 'react'
 import {Box, Heading, Text, FlexContainer, FlexItem} from '@primer/components'
 import Octicon, {Package} from '@githubprimer/octicons-react'
+import LinkLight from './LinkLight'
 import CssImage from './svg/Css.svg'
 import IndexGrid from './IndexGrid'
 import ButtonFill from './ButtonFill'
 import ButtonOutline from './ButtonOutline'
+
+const packages = [
+  {
+    name: 'primer',
+    description: 'This package includes all 30 Primer modules from the core, product, and marketing packages'
+  },
+  {
+    name: 'primer-core',
+    description: 'The core package contains modules that are shared between GitHub product and marketing websites'
+  },
+  {
+    name: 'primer-product',
+    description: 'The product package contains modules that are used on GitHub product websites'
+  },
+  {
+    name: 'primer-marketing',
+    description: 'The marketing package contains modules that are used on GitHub marketing websites'
+  }
+]
 
 export default function PrimerCSS() {
   return (
@@ -40,58 +60,23 @@ export default function PrimerCSS() {
       </IndexGrid>
       <Box px={4} className="container-xl">
         <Box mx={-4} className="d-flex flex-wrap flex-items-start">
-          <FlexContainer width={[1, 6 / 12, 6 / 12]} px={4} mb={[3, 4, 4, 0]}>
-            <FlexItem color="blue.3" mr={3}>
-              <Octicon icon={Package} height={40} verticalAlign="middle" />
-            </FlexItem>
-            <FlexItem>
-              <Text is="p" fontSize={2} color="blue.3" mt={1} className="text-mono">
-                primer
-              </Text>
-              <Text is="p" color="blue.2" mb={4} fontSize={3}>
-                This package includes all 30 Primer modules from the core, product, and marketing packages
-              </Text>
-            </FlexItem>
-          </FlexContainer>
-          <FlexContainer width={[1, 6 / 12, 6 / 12]} px={4} mb={[3, 4, 4, 0]}>
-            <FlexItem color="blue.3" mr={3}>
-              <Octicon icon={Package} height={40} verticalAlign="middle" />
-            </FlexItem>
-            <FlexItem>
-              <Text is="p" fontSize={2} color="blue.3" mt={1} className="text-mono">
-                primer-core
-              </Text>
-              <Text is="p" color="blue.2" mb={4} fontSize={3}>
-                The core package contains modules that are shared between GitHub product and marketing websites
-              </Text>
-            </FlexItem>
-          </FlexContainer>
-          <FlexContainer width={[1, 6 / 12, 6 / 12]} px={4} mb={[3, 4, 4, 0]} align="top">
-            <FlexItem color="blue.3" mr={3}>
-              <Octicon icon={Package} height={40} verticalAlign="middle" />
-            </FlexItem>
-            <FlexItem>
-              <Text is="p" fontSize={2} color="blue.3" mt={1} className="text-mono">
-                primer-product
-              </Text>
-              <Text is="p" color="blue.2" mb={4} fontSize={3}>
-                The product package contains modules that are used on GitHub product websites
-              </Text>
-            </FlexItem>
-          </FlexContainer>
-          <FlexContainer width={[1, 6 / 12, 6 / 12]} px={4} mb={[3, 4, 4, 0]} align="top">
-            <FlexItem color="blue.3" mr={3}>
-              <Octicon icon={Package} height={40} verticalAlign="middle" />
-            </FlexItem>
-            <FlexItem>
-              <Text is="p" fontSize={2} color="blue.3" mt={1} className="text-mono">
-                primer-marketing
-              </Text>
-              <Text is="p" color="blue.2" mb={4} fontSize={3}>
-                The marketing package contains modules that are used on GitHub marketing websites
-              </Text>
-            </FlexItem>
-          </FlexContainer>
+          {packages.map(({name, description}) => (
+            <FlexContainer width={[1, 6 / 12, 6 / 12]} px={4} mb={[3, 4, 4, 0]}>
+              <FlexItem color="blue.3" mr={3}>
+                <Octicon icon={Package} height={40} verticalAlign="middle" />
+              </FlexItem>
+              <FlexItem>
+                <Text is="p" fontSize={2} mt={1} className="text-mono">
+                  <LinkLight href={`https://npm.im/${name}`}>
+                    {name}
+                  </LinkLight>
+                </Text>
+                <Text is="p" color="blue.2" mb={4} fontSize={3}>
+                  {description}
+                </Text>
+              </FlexItem>
+            </FlexContainer>
+          ))}
         </Box>
       </Box>
     </Box>

--- a/src/PrimerCSS.js
+++ b/src/PrimerCSS.js
@@ -61,15 +61,13 @@ export default function PrimerCSS() {
       <Box px={4} className="container-xl">
         <Box mx={-4} className="d-flex flex-wrap flex-items-start">
           {packages.map(({name, description}) => (
-            <FlexContainer width={[1, 6 / 12, 6 / 12]} px={4} mb={[3, 4, 4, 0]}>
+            <FlexContainer key={name} width={[1, 6 / 12, 6 / 12]} px={4} mb={[3, 4, 4, 0]}>
               <FlexItem color="blue.3" mr={3}>
                 <Octicon icon={Package} height={40} verticalAlign="middle" />
               </FlexItem>
               <FlexItem>
                 <Text is="p" fontSize={2} mt={1} className="text-mono">
-                  <LinkLight href={`https://npm.im/${name}`}>
-                    {name}
-                  </LinkLight>
+                  <LinkLight href={`https://npm.im/${name}`}>{name}</LinkLight>
                 </Text>
                 <Text is="p" color="blue.2" mb={4} fontSize={3}>
                   {description}


### PR DESCRIPTION
This does a couple of things:

1. DRYs up the OpenSource (footer) component with FooterOcticon and FooterLink components.
1. DRYs up the PrimerCSS component to iterate over an array of packages rather than duplicating the markup, and wraps the package names in `npm.im` links.
1. Adds an Octicon component with color and space props so that we don't have to use utility classes. So this:

    ```js
    import Octicon, {Zap} from '@githubprimer/octicons-react'
    ```

    becomes:

    ```js
    import Octicon from './Octicon'
    import {Zap} from '@githubprimer/octicons-react'
    ```

