### PR TITLE
Fix preview deployments for branches with non-word chars

### DIFF
--- a/script/deploy-preview
+++ b/script/deploy-preview
@@ -1,6 +1,6 @@
 #!/bin/bash
 set -e
-branch="$TRAVIS_BRANCH"
+branch="$(node -e "console.log('$TRAVIS_BRANCH'.replace(/[^-\w]+/g, '-'))")"
 root="$(now-github-url --ref="$TRAVIS_COMMIT")"
 if [[ -z "$root" ]]; then
     echo "No root deployment found for branch: '$branch'"

--- a/script/deploy-preview
+++ b/script/deploy-preview
@@ -1,6 +1,6 @@
 #!/bin/bash
 set -e
-branch="$(node -e "console.log('$TRAVIS_BRANCH'.replace(/[^-\w]+/g, '-'))")"
+branch="$(node -e "console.log('$TRAVIS_BRANCH'.replace(/[^-a-z]+/g, '-').toLowerCase())")"
 root="$(now-github-url --ref="$TRAVIS_COMMIT")"
 if [[ -z "$root" ]]; then
     echo "No root deployment found for branch: '$branch'"


### PR DESCRIPTION
This is an attempt to fix #51. Rather than just interpolating `$TRAVIS_BRANCH` into the deployment URL as-is, we run it through a Node one-liner that replaces any sequence of non-word (or hyphen) characters in the branch name with a hyphen, so `foo/bar` becomes `foo-bar`, `brocs/spacing` becomes `brocs-spacing`, etc.

I've pushed this same commit to the `test/fix-branch-preview` branch to test it. If that branch deploys to `primer-style-test-fix-branch-preview.now.sh`, then we've got a winner.