### PR TITLE
correct doc links typo

### DIFF
--- a/src/OcticonsPromo.js
+++ b/src/OcticonsPromo.js
@@ -38,11 +38,11 @@ const OcticonsPromo = props => (
     <Box className="container-xl mx-auto" color="blue.2">
       <FlexContainer mx={-4} className="flex-wrap">
 
-        <Package icon={FileCode} href="https://github.com/primer/octicons/#ruby" title="JavaScript docs">
+        <Package icon={FileCode} href="https://github.com/primer/octicons/#javascript" title="JavaScript docs">
           Install the node.js or react.js package via npm to use with your JavaScript project
         </Package>
 
-        <Package icon={Ruby} href="https://github.com/primer/octicons/#javascript" title="Ruby docs">
+        <Package icon={Ruby} href="https://github.com/primer/octicons/#ruby" title="Ruby docs">
           Install the Ruby gem, Rails helper, or Jekyll plugin to use in your project
         </Package>
 


### PR DESCRIPTION
Correct doc links to `octicons/#javascript` and `octicons/#ruby`