### PR TITLE
More draggable fixes

### DIFF
--- a/pages/_app.js
+++ b/pages/_app.js
@@ -18,6 +18,10 @@ export default class Page extends React.Component {
     initDraggables()
   }
 
+  componentDidUpdate() {
+    initDraggables()
+  }
+
   render() {
     const {children} = this.props
     return (

--- a/src/draggable.js
+++ b/src/draggable.js
@@ -9,8 +9,8 @@ const resizeAll = throttle(30, false, () => {
 })
 
 export function initDraggables() {
-  if (global.DRAGGABLES) {
-    removeDraggables(global.DRAGGABLES)
+  if (draggables) {
+    removeDraggables(draggables)
   }
 
   const attr = 'data-draggable'
@@ -33,15 +33,11 @@ export function initDraggables() {
   }
 }
 
-export function removeDraggables() {
-  const existing = global.DRAGGABLES
-  if (existing) {
-    while (existing.length) {
-      existing.shift().remove()
-    }
-    window.removeEventListener('resize', resizeAll)
-    global.DRAGGABLES = null
+export function removeDraggables(existing) {
+  while (existing.length) {
+    existing.shift().remove()
   }
+  window.removeEventListener('resize', resizeAll)
 }
 
 export class Draggable {

--- a/src/draggable.js
+++ b/src/draggable.js
@@ -1,10 +1,6 @@
 import {throttle} from 'throttle-debounce'
 
-if (global.DRAGGABLES) {
-  removeDraggables(global.DRAGGABLES)
-}
-
-const draggables = (global.DRAGGABLES = [])
+let draggables
 
 const resizeAll = throttle(30, false, () => {
   for (const draggable of draggables) {
@@ -13,8 +9,13 @@ const resizeAll = throttle(30, false, () => {
 })
 
 export function initDraggables() {
+  if (global.DRAGGABLES) {
+    removeDraggables(global.DRAGGABLES)
+  }
+
   const attr = 'data-draggable'
 
+  draggables = []
   for (const el of document.querySelectorAll(`[${attr}]`)) {
     const index = draggables.findIndex(d => d.source === el)
     if (index > -1) {
@@ -26,19 +27,21 @@ export function initDraggables() {
     draggables.push(new Draggable(el))
   }
 
-  window.addEventListener('resize', resizeAll)
-  return draggables
+  if (draggables.length) {
+    window.addEventListener('resize', resizeAll)
+    global.DRAGGABLES = draggables
+  }
 }
 
-export function removeDraggables(existing) {
-  if (existing.length) {
-    // eslint-disable-next-line no-console
-    console.warn(`removing ${existing.length} existing draggables...`)
+export function removeDraggables() {
+  const existing = global.DRAGGABLES
+  if (existing) {
     while (existing.length) {
       existing.shift().remove()
     }
+    window.removeEventListener('resize', resizeAll)
+    global.DRAGGABLES = null
   }
-  window.removeEventListener('resize', resizeAll)
 }
 
 export class Draggable {


### PR DESCRIPTION
This defensively cleans up and re-initializes our SVG "draggables" whenever the App updates — which, because we're using react-router, happens whenever you click between the team and home pages. I've tested locally that this fixes the issues of:

1. draggables sticking around when transitioning from home to team
2. elements that should be draggable no longer working when transitioning from team to home

TIL that you need both `componentDidMount()` and `componentDidUpdate()` lifecycle methods to "listen" for every time a react component renders. ✨ 