### PR TITLE
Team Page Dot Positioning + Updated Team Photos

### DIFF
--- a/src/MemberContainer.js
+++ b/src/MemberContainer.js
@@ -9,8 +9,8 @@ const oddDots = `
   height: 92px;
   width: 168px;
   position: absolute;
-  top: 220px;
-  left: 145px;
+  top: 210px;
+  left: 170px;
   transform: rotate(-180deg);
 }`
 const evenDots = `
@@ -18,8 +18,8 @@ const evenDots = `
   height: 92px;
   width: 168px;
   position: absolute;
-  top: 234px;
-  left: 46px;
+  top: 245px;
+  left: 75px;
 }`
 
 const direction = isOdd =>

--- a/src/MemberContainer.js
+++ b/src/MemberContainer.js
@@ -5,36 +5,33 @@ import AvatarShape from './AvatarShape'
 import DotsSVG from './svg/dots.svg'
 
 const Dots = ({shape}) => {
-  let css = {
+  const css = {
     position: 'absolute',
     height: '92px',
     width: '168px'
   }
   switch (shape) {
     case 'hexagon':
-      css.top = '230px';
-      css.left = '130px';
-      css.transform = 'rotate(180deg)';
-      break;
+      css.top = '230px'
+      css.left = '130px'
+      css.transform = 'rotate(180deg)'
+      break
     case 'square':
-      css.top = '250px';
-      css.left = '75px';
-      break;
+      css.top = '250px'
+      css.left = '75px'
+      break
     case 'circle':
-      css.top = '236px';
-      css.left = '181px';
-      css.transform = 'rotate(180deg)';
-      break;
+      css.top = '236px'
+      css.left = '181px'
+      css.transform = 'rotate(180deg)'
+      break
     case 'diamond':
-      css.top = '245px';
-      css.left = '65px';
-      break;
+      css.top = '245px'
+      css.left = '65px'
+      break
     default:
-
   }
-  return (
-    <DotsSVG shape={shape} style={css} />
-  )
+  return <DotsSVG shape={shape} style={css} />
 }
 
 const direction = isOdd =>

--- a/src/MemberContainer.js
+++ b/src/MemberContainer.js
@@ -4,23 +4,38 @@ import MemberQuestions from './MemberQuestions'
 import AvatarShape from './AvatarShape'
 import DotsSVG from './svg/dots.svg'
 
-const oddDots = `
-{
-  height: 92px;
-  width: 168px;
-  position: absolute;
-  top: 210px;
-  left: 170px;
-  transform: rotate(-180deg);
-}`
-const evenDots = `
-{
-  height: 92px;
-  width: 168px;
-  position: absolute;
-  top: 245px;
-  left: 75px;
-}`
+const Dots = ({shape}) => {
+  let css = {
+    position: 'absolute',
+    height: '92px',
+    width: '168px'
+  }
+  switch (shape) {
+    case 'hexagon':
+      css.top = '230px';
+      css.left = '130px';
+      css.transform = 'rotate(180deg)';
+      break;
+    case 'square':
+      css.top = '250px';
+      css.left = '75px';
+      break;
+    case 'circle':
+      css.top = '236px';
+      css.left = '181px';
+      css.transform = 'rotate(180deg)';
+      break;
+    case 'diamond':
+      css.top = '245px';
+      css.left = '65px';
+      break;
+    default:
+
+  }
+  return (
+    <DotsSVG shape={shape} style={css} />
+  )
+}
 
 const direction = isOdd =>
   isOdd
@@ -38,7 +53,7 @@ const Member = ({member, isOdd, shape}) => (
     <FlexItem mb={[6, 8, 8, 0, 0]} flexShrink="0" style={{position: 'relative'}}>
       <Box mr={isOdd ? [0, 0, 0, 12, 12] : 0} ml={isOdd ? 0 : [0, 0, 12, 12, 12]}>
         <AvatarShape shape={shape} src={member.avatar} />
-        <DotsSVG css={isOdd ? oddDots : evenDots} />
+        <Dots shape={shape} />
       </Box>
     </FlexItem>
   </FlexContainer>

--- a/src/team-content.js
+++ b/src/team-content.js
@@ -29,7 +29,7 @@ const teamContent = [
     questionOne: `I worked in data visualization and map-making for most of my career, and solving design problems with data is my jam. To me there's something uniquely exciting about making a thing that can take complicated and/or unexpected input and, with no human intervention, reduce it to something visually comprehensible—and hopefully interesting!`,
     questionTwo: `Anyone who has ever contributed to [A List Apart](http://alistapart.com/) or posted to the [webdesign-l](http://www.webdesign-l.com/) mailing list between 1999 and 2005. The [CSS Zen Garden](http://www.csszengarden.com/) was hugely inspirational for me, along with web standards pioneers like Eric Meyer, Mark Pilgrim, and Jeff Zeldman. [Jina](https://twitter.com/jina) is one of the hardest-working people in design systems, and her leadership in the community is a tremendous inspiration. I learned everything I know about SVG from [Sara Soueidan](https://twitter.com/SaraSoueidan), and everything I could _hope_ to know about CSS Grid from [Rachel Andrew](https://twitter.com/rachelandrew) and [Jen Simmons](https://twitter.com/jensimmons). If you want to learn about web components, follow [Monica Dinculescu](https://twitter.com/notwaldorf) and [Mu-An Chiou](https://twitter.com/muanchiou).`,
     favoriteTools: 'Vim, Things, Chrome DevTools, curl',
-    avatar: 'https://user-images.githubusercontent.com/8960591/46552708-5b746280-c890-11e8-90df-654d77ecbb89.jpg'
+    avatar: 'https://user-images.githubusercontent.com/586552/46751266-f81b7380-cc87-11e8-8459-2166a1c40f63.jpg'
   },
   {
     name: 'Jon Rohan',
@@ -50,7 +50,7 @@ const teamContent = [
       'I was drawn to design systems for many reasons—the opportunity to improve design and development workflow efficiency; the potential benefits well-design systems can bring to the user experience; I like to bring order to chaos and enjoy working at the intersection of design and code. I also love that there is still so much to learn in the field and really enjoy the passion of the community behind design systems.',
     questionTwo: `I don't have room on this webpage to list everyone! [SMACSS](https://smacss.com/), [The Art and Science of CSS](https://www.amazon.com/Science-Jonathan-Bolton-Cameron-Paperback/dp/B00ZVORUW6), and [Veerle Pieters](http://veerle.duoh.com/) were some early influences. [OOCSS](https://github.com/stubbornella/oocss/wiki) by Nicole Sullivan, [CSS Wizardary](https://csswizardry.com/), [Basscss](http://basscss.com/), [Tachyons](https://tachyons.io/), and [BEM](http://getbem.com/naming/) influenced my approach to CSS architecture. More recently I've been inspired by Rune Madsen's [Programming Design Systems](https://programmingdesignsystems.com), [Compositor](https://github.com/c8r), [Dan Abramov](https://twitter.com/dan_abramov), [Sebastian Markbage](https://youtu.be/4anAwXYqLG8), and so many design and code wonder women like [Many Kerr](https://twitter.com/mandy_kerr), [Marcy Sutton](https://twitter.com/marcysutton), [Lea Verou](https://twitter.com/LeaVerou), [Sarah Drasner](https://twitter.com/sarah_edo) and [Jina Anne](https://twitter.com/jina).`,
     favoriteTools: 'Hyper, Atom, Figma, MDN, and Quip',
-    avatar: 'https://user-images.githubusercontent.com/586552/46690196-b4fdc980-cbcf-11e8-8379-eaae729b5158.jpg'
+    avatar: 'https://user-images.githubusercontent.com/586552/46751001-5c8a0300-cc87-11e8-84bb-9024b03df74f.jpg'
   }
 ]
 


### PR DESCRIPTION
Trying to get this closer to where they were yesterday, I think it might have been slightly off because the SVG is now inline vs. being positioned as a background-image on the image. Regardless, we should be able to get them close, might take some more nudging around.

If someone wants to take a stab at moving these around, feel free – right now the circle avatar has the weirdest composition :/ the rest look okay to me. 

![screenshot 2018-10-10 11 09 26](https://user-images.githubusercontent.com/586552/46746398-fd26f580-cc7c-11e8-80a8-b33435283dbd.png)
![screenshot 2018-10-10 11 09 22](https://user-images.githubusercontent.com/586552/46746399-fd26f580-cc7c-11e8-8fc7-5dab7b1c5be8.png)
![screenshot 2018-10-10 11 09 17](https://user-images.githubusercontent.com/586552/46746400-fd26f580-cc7c-11e8-9f7c-c28412312953.png)
![screenshot 2018-10-10 11 09 08](https://user-images.githubusercontent.com/586552/46746401-fd26f580-cc7c-11e8-950b-1237156e635d.png)


