### PR TITLE
Factor out Primer CSS utilities

### DIFF
--- a/pages/team/index.js
+++ b/pages/team/index.js
@@ -12,7 +12,7 @@ const getMemberContent = () => {
   let shapeIndex = 0
   return teamContent.map((member, i) => {
     if (i === shapes.length) shapeIndex = 0
-    const element = <MemberContainer shape={shapes[shapeIndex]} isOdd={i % 2 === 0} member={member} />
+    const element = <MemberContainer key={member.name} shape={shapes[shapeIndex]} isOdd={i % 2 === 0} member={member} />
     shapeIndex++
     return element
   })

--- a/pages/team/index.js
+++ b/pages/team/index.js
@@ -21,7 +21,7 @@ const getMemberContent = () => {
 const TeamIndex = () => (
   <Box>
     <Nav />
-    <Box className="container-xl" pt={7} px={5} style={{overflow: 'hidden'}}>
+    <Box className="container-xl" pt={7} px={5} css={{overflow: 'hidden'}}>
       <FlexContainer
         justifyContent="space-between"
         flexDirection={['column-reverse', 'column-reverse', 'column-reverse', 'row', 'row']}

--- a/src/AtomPlugins.js
+++ b/src/AtomPlugins.js
@@ -7,7 +7,7 @@ import IndexGrid from './IndexGrid'
 
 export default function AtomPlugins() {
   return (
-    <IndexGrid my={[0, 3, 6]} flexDirection={[`row`, `row`, `row-reverse`]}>
+    <IndexGrid my={[0, 3, 6]} flexDirection={['row', 'row', 'row-reverse']}>
       <IndexGrid.Item mb={[5, 5, 5, 0]}>
         <AtomImage width="100%" height={null} />
       </IndexGrid.Item>

--- a/src/AtomPlugins.js
+++ b/src/AtomPlugins.js
@@ -24,7 +24,7 @@ export default function AtomPlugins() {
         <ButtonOutline my={[2, 0]} href="https://atom.io/">
           Get Atom
         </ButtonOutline>
-        <Text is="p" fontSize={2} mt={5} color="blue.3" className="text-mono">
+        <Text is="p" fontSize={2} mt={5} color="blue.3" fontFamily="mono">
           apm install autocomplete-primer
         </Text>
       </IndexGrid.Item>

--- a/src/HiringPromo.js
+++ b/src/HiringPromo.js
@@ -1,5 +1,5 @@
 import React from 'react'
-import {Box, Heading, Text} from '@primer/components'
+import {Heading, Text} from '@primer/components'
 import styled from 'react-emotion'
 import {textAlign} from 'styled-system'
 import Octicon from './Octicon'

--- a/src/HiringPromo.js
+++ b/src/HiringPromo.js
@@ -1,13 +1,18 @@
 import React from 'react'
 import {Box, Heading, Text} from '@primer/components'
+import styled from 'react-emotion'
+import {textAlign} from 'styled-system'
 import Octicon from './Octicon'
 import {RadioTower} from '@githubprimer/octicons-react'
 import ButtonPromo from './ButtonPromo'
 import LinkPromo from './LinkPromo'
 
+// FIXME: when textAlign is added to LAYOUT props, we can remove this
+const AlignBox = styled(Box)(textAlign)
+
 export default function HiringPromo() {
   return (
-    <Box align="center" px={5} className="container-lg text-left text-md-center">
+    <AlignBox px={5} textAlign={['left', 'left', 'center']} className="container-lg">
       <Heading fontSize={5} mb={2} color="orange.3">
         <Octicon icon={RadioTower} mr={3} size={40} verticalAlign="top" />
         Join GitHub!
@@ -22,6 +27,6 @@ export default function HiringPromo() {
       <ButtonPromo block my={[2, 0]} href="https://boards.greenhouse.io/github/jobs/1306815">
         Apply →
       </ButtonPromo>
-    </Box>
+    </AlignBox>
   )
 }

--- a/src/HiringPromo.js
+++ b/src/HiringPromo.js
@@ -1,18 +1,13 @@
 import React from 'react'
 import {Heading, Text} from '@primer/components'
-import styled from 'react-emotion'
-import {textAlign} from 'styled-system'
-import Octicon from './Octicon'
 import {RadioTower} from '@githubprimer/octicons-react'
+import Octicon from './Octicon'
 import ButtonPromo from './ButtonPromo'
 import LinkPromo from './LinkPromo'
 
-// FIXME: when textAlign is added to LAYOUT props, we can remove this
-const AlignText = styled(Text)(textAlign)
-
 export default function HiringPromo() {
   return (
-    <AlignText is="div" px={5} textAlign={['left', 'left', 'center']} className="container-lg">
+    <Text is="div" px={5} textAlign={['left', 'left', 'center']} className="container-lg">
       <Heading fontSize={5} mb={2} color="orange.3">
         <Octicon icon={RadioTower} mr={3} size={40} verticalAlign="top" />
         Join GitHub!
@@ -27,6 +22,6 @@ export default function HiringPromo() {
       <ButtonPromo block my={[2, 0]} href="https://boards.greenhouse.io/github/jobs/1306815">
         Apply →
       </ButtonPromo>
-    </AlignText>
+    </Text>
   )
 }

--- a/src/HiringPromo.js
+++ b/src/HiringPromo.js
@@ -8,11 +8,11 @@ import ButtonPromo from './ButtonPromo'
 import LinkPromo from './LinkPromo'
 
 // FIXME: when textAlign is added to LAYOUT props, we can remove this
-const AlignBox = styled(Box)(textAlign)
+const AlignText = styled(Text)(textAlign)
 
 export default function HiringPromo() {
   return (
-    <AlignBox px={5} textAlign={['left', 'left', 'center']} className="container-lg">
+    <AlignText is="div" px={5} textAlign={['left', 'left', 'center']} className="container-lg">
       <Heading fontSize={5} mb={2} color="orange.3">
         <Octicon icon={RadioTower} mr={3} size={40} verticalAlign="top" />
         Join GitHub!
@@ -27,6 +27,6 @@ export default function HiringPromo() {
       <ButtonPromo block my={[2, 0]} href="https://boards.greenhouse.io/github/jobs/1306815">
         Apply →
       </ButtonPromo>
-    </AlignBox>
+    </AlignText>
   )
 }

--- a/src/HiringPromo.js
+++ b/src/HiringPromo.js
@@ -1,6 +1,7 @@
 import React from 'react'
 import {Box, Heading, Text} from '@primer/components'
-import Octicon, {RadioTower} from '@githubprimer/octicons-react'
+import Octicon from './Octicon'
+import {RadioTower} from '@githubprimer/octicons-react'
 import ButtonPromo from './ButtonPromo'
 import LinkPromo from './LinkPromo'
 
@@ -8,7 +9,7 @@ export default function HiringPromo() {
   return (
     <Box align="center" px={5} className="container-lg text-left text-md-center">
       <Heading fontSize={5} mb={2} color="orange.3">
-        <Octicon className="mr-3" icon={RadioTower} size={40} verticalAlign="top" />
+        <Octicon icon={RadioTower} mr={3} size={40} verticalAlign="top" />
         Join GitHub!
       </Heading>
       <Text is="p" fontSize={3} mb={5} px={[0, 0, 0, 5]} color="orange.1">

--- a/src/LinkDark.js
+++ b/src/LinkDark.js
@@ -1,11 +1,12 @@
 // Extends Link from primer/components to make color primitives available. Ideally I'd use defaultProps here but because we use !important on utilities the theme colors won't override. We could probably add a function to handle this.
 
 import {Link} from '@primer/components'
-import {themeGet} from 'styled-system'
+import {display, themeGet} from 'styled-system'
 import styled from 'react-emotion'
 
 const LinkDark = styled(Link)`
   color: ${themeGet('colors.black')} !important;
+  ${display};
   &:hover {
     color: ${themeGet('colors.gray.8')};
   }

--- a/src/LinkLight.js
+++ b/src/LinkLight.js
@@ -1,11 +1,12 @@
 // Extends Link from primer/components to make color primitives available. Ideally I'd use defaultProps here but because we use !important on utilities the theme colors won't override. We could probably add a function to handle this.
 
 import {Link} from '@primer/components'
-import {themeGet} from 'styled-system'
+import {display, themeGet} from 'styled-system'
 import styled from 'react-emotion'
 
 const LinkLight = styled(Link)`
   color: ${themeGet('colors.blue.3')} !important;
+  ${display};
 `
 
 LinkLight.defaultProps = {

--- a/src/MemberContainer.js
+++ b/src/MemberContainer.js
@@ -47,7 +47,7 @@ const Member = ({member, isOdd, shape}) => (
     flexDirection={direction(isOdd)}
   >
     <MemberQuestions member={member} />
-    <FlexItem mb={[6, 8, 8, 0, 0]} css={{flexShrink: 0}} style={{position: 'relative'}}>
+    <FlexItem mb={[6, 8, 8, 0, 0]} css={{flexShrink: 0, position: 'relative'}}>
       <Box mr={isOdd ? [0, 0, 0, 12, 12] : 0} ml={isOdd ? 0 : [0, 0, 12, 12, 12]}>
         <AvatarShape shape={shape} src={member.avatar} />
         <Dots shape={shape} />

--- a/src/MemberQuestions.js
+++ b/src/MemberQuestions.js
@@ -24,7 +24,7 @@ const MemberInfo = ({member}) => (
       fontSize={2}
       href={`https://github.com/${member.github}`}
     >
-      <Octicon icon={MarkGithub} size="24" verticalAlign="middle" color="blue.3" mr={3} />@{member.handle}
+      <Octicon icon={MarkGithub} size={24} verticalAlign="middle" color="blue.3" mr={3} />@{member.handle}
     </Link>
     <Text fontFamily="mono" color="blue.4" is="div" fontSize={3} mt={7} mb={0}>
       What drew you into design systems?

--- a/src/MemberQuestions.js
+++ b/src/MemberQuestions.js
@@ -1,6 +1,7 @@
 import React from 'react'
 import {Text, Heading, Link, Box} from '@primer/components'
-import Octicon, {MarkGithub} from '@githubprimer/octicons-react'
+import Octicon from './Octicon'
+import {MarkGithub} from '@githubprimer/octicons-react'
 import {injectGlobal} from 'emotion'
 import ReactMarkdown from 'react-markdown'
 
@@ -23,7 +24,7 @@ const MemberInfo = ({member}) => (
       fontSize={2}
       href={`https://github.com/${member.github}`}
     >
-      <Octicon size="24" verticalAlign="middle" color="blue.3" className="mr-3" icon={MarkGithub} />@{member.handle}
+      <Octicon icon={MarkGithub} size="24" verticalAlign="middle" color="blue.3" mr={3} />@{member.handle}
     </Link>
     <Text fontFamily="mono" color="blue.4" is="div" fontSize={3} mt={7} mb={0}>
       What drew you into design systems?

--- a/src/Nav.js
+++ b/src/Nav.js
@@ -10,12 +10,12 @@ export default function Nav() {
       <Flex alignItems="center">
         <Flex flex="auto">
           <RouterLink style={{color: 'inherit'}} to="/">
-            <FlexContainer color="blue.2" alignItems="center">
+            <Flex color="blue.2" alignItems="center">
               <Octicon icon={MarkGithub} ariaLabel="Primer home" size="medium" />
               <Text mx={3} fontSize="2" lineHeight="condensed">
                 Primer
               </Text>
-            </FlexContainer>
+            </Flex>
           </RouterLink>
         </Flex>
         <Text is="div" fontSize={2} color="blue.2">

--- a/src/Nav.js
+++ b/src/Nav.js
@@ -1,7 +1,8 @@
 import React from 'react'
 import {Box, FlexContainer, Text} from '@primer/components'
-import Octicon, {MarkGithub} from '@githubprimer/octicons-react'
+import {MarkGithub} from '@githubprimer/octicons-react'
 import {Link as RouterLink} from 'react-router-dom'
+import Octicon from './Octicon'
 
 export default function Nav() {
   return (
@@ -10,7 +11,7 @@ export default function Nav() {
         <FlexContainer flex="auto">
           <RouterLink style={{color: 'inherit'}} to="/">
             <Box color="blue.2" className="d-flex flex-items-center">
-              <Octicon color="blue.2" icon={MarkGithub} ariaLabel="Primer home" size="medium" />
+              <Octicon icon={MarkGithub} color="blue.2" ariaLabel="Primer home" size="medium" />
               <Text mx={3} color="blue.2" fontSize="2" lineHeight="condensed">
                 Primer
               </Text>

--- a/src/Nav.js
+++ b/src/Nav.js
@@ -11,8 +11,8 @@ export default function Nav() {
         <FlexContainer flex="auto">
           <RouterLink style={{color: 'inherit'}} to="/">
             <FlexContainer color="blue.2" alignItems="center">
-              <Octicon icon={MarkGithub} color="blue.2" ariaLabel="Primer home" size="medium" />
-              <Text mx={3} color="blue.2" fontSize="2" lineHeight="condensed">
+              <Octicon icon={MarkGithub} ariaLabel="Primer home" size="medium" />
+              <Text mx={3} fontSize="2" lineHeight="condensed">
                 Primer
               </Text>
             </FlexContainer>

--- a/src/Nav.js
+++ b/src/Nav.js
@@ -10,12 +10,12 @@ export default function Nav() {
       <FlexContainer alignItems="center">
         <FlexContainer flex="auto">
           <RouterLink style={{color: 'inherit'}} to="/">
-            <Box color="blue.2" className="d-flex flex-items-center">
+            <FlexContainer color="blue.2" alignItems="center">
               <Octicon icon={MarkGithub} color="blue.2" ariaLabel="Primer home" size="medium" />
               <Text mx={3} color="blue.2" fontSize="2" lineHeight="condensed">
                 Primer
               </Text>
-            </Box>
+            </FlexContainer>
           </RouterLink>
         </FlexContainer>
         <Text is="div" fontSize={2} color="blue.2">

--- a/src/Nav.js
+++ b/src/Nav.js
@@ -7,7 +7,7 @@ import Octicon from './Octicon'
 export default function Nav() {
   return (
     <Box bg="gray.9" py={3} px={5}>
-      <div className="d-flex flex-items-center">
+      <FlexContainer alignItems="center">
         <FlexContainer flex="auto">
           <RouterLink style={{color: 'inherit'}} to="/">
             <Box color="blue.2" className="d-flex flex-items-center">
@@ -23,7 +23,7 @@ export default function Nav() {
             Meet the team
           </RouterLink>
         </Text>
-      </div>
+      </FlexContainer>
     </Box>
   )
 }

--- a/src/OcticonsPromo.js
+++ b/src/OcticonsPromo.js
@@ -1,7 +1,8 @@
 import React from 'react'
 import {Box, Heading, Text, Link, FlexContainer, FlexItem, Relative} from '@primer/components'
+import {FileCode, Ruby, Paintcan} from '@githubprimer/octicons-react'
+import Octicon from './Octicon'
 import OcticonsImage from './svg/Octicons.svg'
-import Octicon, {FileCode, Ruby, Paintcan} from '@githubprimer/octicons-react'
 import LinkLight from './LinkLight'
 
 export default function OcticonsPromo() {
@@ -54,7 +55,7 @@ function Package({children, icon, href, title, ...rest}) {
     <FlexContainer width={[1, 1, 1, 1 / 3]} px={5} mb={[4, 5, 5, 0]} {...rest}>
       <FlexItem color="blue.3">
         <Box width={44}>
-          <Octicon className="mr-3" icon={icon} height={40} verticalAlign="top" />
+          <Octicon icon={icon} mr={3} height={40} verticalAlign="top" />
         </Box>
       </FlexItem>
       <FlexItem px={2}>

--- a/src/OcticonsPromo.js
+++ b/src/OcticonsPromo.js
@@ -62,7 +62,7 @@ function Package({children, icon, href, title, ...rest}) {
         <Text is="p" fontSize={2}>
           {children}
         </Text>
-        <LinkLight className="d-inline-block" href={href}>
+        <LinkLight display="inline-block" href={href}>
           {title} →
         </LinkLight>
       </FlexItem>

--- a/src/OcticonsPromo.js
+++ b/src/OcticonsPromo.js
@@ -10,7 +10,7 @@ export default function OcticonsPromo() {
     <Box pb={12} px={5}>
       <Box align="center" mb={8} mx="auto" className="container-xl">
         <Relative zIndex={100} mt={[4, 3, 0]} width={[1, 1, 1, 6 / 12]}>
-          <Link href="http://octicons.github.com/" className="no-underline">
+          <Link href="http://octicons.github.com/">
             <Heading lineHeight="1.25" color="blue.4" mb={2} fontSize={7} fontWeight="bold">
               Octicons
             </Heading>

--- a/src/OcticonsPromo.js
+++ b/src/OcticonsPromo.js
@@ -18,7 +18,7 @@ export default function OcticonsPromo() {
           <Text is="p" color="blue.1" mb={[2, 3]} fontSize={[4, 5]}>
             Your project. GitHub&#8217;s icons.
           </Text>
-          <Text fontSize={2} color="blue.3" className="text-mono">
+          <Text fontSize={2} color="blue.3" fontFamily="mono">
             v8.1.0
           </Text>
         </Relative>

--- a/src/OcticonsPromo.js
+++ b/src/OcticonsPromo.js
@@ -8,7 +8,7 @@ import LinkLight from './LinkLight'
 export default function OcticonsPromo() {
   return (
     <Box pb={12} px={5}>
-      <Box align="center" mb={8} className="container-xl mx-auto">
+      <Box align="center" mb={8} mx="auto" className="container-xl">
         <Relative zIndex={100} mt={[4, 3, 0]} width={[1, 1, 1, 6 / 12]}>
           <Link href="http://octicons.github.com/" className="no-underline">
             <Heading lineHeight="1.25" color="blue.4" mb={2} fontSize={7} fontWeight="bold">
@@ -27,7 +27,7 @@ export default function OcticonsPromo() {
         </Box>
       </Box>
 
-      <Box className="container-xl mx-auto" color="blue.2">
+      <Box mx="auto" className="container-xl" color="blue.2">
         <FlexContainer flexWrap="wrap" mx={-5}>
           <Package icon={FileCode} href="https://github.com/primer/octicons/#ruby" title="JavaScript docs">
             Install the node.js or react.js package via npm to use with your JavaScript project

--- a/src/OpenSource.js
+++ b/src/OpenSource.js
@@ -42,7 +42,7 @@ export default function OpenSource() {
           </LinkDark>
         </IndexGrid.Item>
       </IndexGrid>
-      <Box color="black" px={5} className="container-xl mx-auto">
+      <Box color="black" px={5} mx="auto" className="container-xl">
         <Box mt={12} py={5} borderTop={2} borderColor="black">
           <Text pr={1} is="span">
             Created and maintained by GitHub&#8217;s

--- a/src/OpenSource.js
+++ b/src/OpenSource.js
@@ -1,6 +1,7 @@
 import React from 'react'
 import {Box, Heading, Text} from '@primer/components'
-import Octicon, {Octoface, MarkGithub} from '@githubprimer/octicons-react'
+import {Octoface, MarkGithub} from '@githubprimer/octicons-react'
+import Octicon from './Octicon'
 import ButtonFillDark from './ButtonFillDark'
 import TwitterIcon from './TwitterIcon'
 import SpectrumIcon from './SpectrumIcon'
@@ -19,7 +20,7 @@ export default function OpenSource() {
             Primer is open-sourced on GitHub. Contributions and feedback are welcome!
           </Text>
           <ButtonFillDark mr={2} href="https://github.com/primer">
-            <Octicon color="blue.2" icon={MarkGithub} size={20} verticalAlign="text-bottom" className="mr-2" />
+            <Octicon icon={MarkGithub} color="blue.2" size={20} verticalAlign="text-bottom" mr={2} />
             Contribute on GitHub
           </ButtonFillDark>
         </IndexGrid.Item>
@@ -28,15 +29,15 @@ export default function OpenSource() {
             Keep in touch
           </Heading>
           <LinkDark pt={1} fontSize={2} mb={3} className="d-block" href="https://twitter.com/githubprimer">
-            <Octicon color="blue.2" icon={TwitterIcon} size={20} verticalAlign="top" className="mr-2" />
+            <Octicon icon={TwitterIcon} color="blue.2" size={20} verticalAlign="top" mr={2} />
             Follow us on Twitter
           </LinkDark>
           <LinkDark fontSize={2} mb={3} className="d-block" href="https://spectrum.chat/primer">
-            <Octicon color="blue.2" icon={SpectrumIcon} size={20} verticalAlign="top" className="mr-2" />
+            <Octicon icon={SpectrumIcon} color="blue.2" size={20} verticalAlign="top" mr={2} />
             Chat with us in Spectrum
           </LinkDark>
           <LinkDark fontSize={2} mb={3} className="d-block" href="https://github.com/primer/primer/issues/new/choose">
-            <Octicon color="blue.2" icon={Octoface} size={20} verticalAlign="text-top" className="mr-2" />
+            <Octicon icon={Octoface} color="blue.2" size={20} verticalAlign="text-top" mr={2} />
             Share feedback on GitHub
           </LinkDark>
         </IndexGrid.Item>

--- a/src/OpenSource.js
+++ b/src/OpenSource.js
@@ -20,7 +20,7 @@ export default function OpenSource() {
             Primer is open-sourced on GitHub. Contributions and feedback are welcome!
           </Text>
           <ButtonFillDark mr={2} href="https://github.com/primer">
-            <Octicon icon={MarkGithub} color="blue.2" size={20} verticalAlign="text-bottom" mr={2} />
+            <Octicon icon={MarkGithub} size={20} verticalAlign="text-bottom" mr={2} />
             Contribute on GitHub
           </ButtonFillDark>
         </IndexGrid.Item>
@@ -28,16 +28,16 @@ export default function OpenSource() {
           <Heading lineHeight="1.25" color="black" mb={3} fontSize={7} fontWeight="bold">
             Keep in touch
           </Heading>
-          <LinkDark pt={1} fontSize={2} mb={3} className="d-block" href="https://twitter.com/githubprimer">
-            <Octicon icon={TwitterIcon} color="blue.2" size={20} verticalAlign="top" mr={2} />
+          <LinkDark pt={1} fontSize={2} mb={3} display="block" href="https://twitter.com/githubprimer">
+            <Octicon icon={TwitterIcon} size={20} verticalAlign="top" mr={2} />
             Follow us on Twitter
           </LinkDark>
-          <LinkDark fontSize={2} mb={3} className="d-block" href="https://spectrum.chat/primer">
-            <Octicon icon={SpectrumIcon} color="blue.2" size={20} verticalAlign="top" mr={2} />
+          <LinkDark fontSize={2} mb={3} display="block" href="https://spectrum.chat/primer">
+            <Octicon icon={SpectrumIcon} size={20} verticalAlign="top" mr={2} />
             Chat with us in Spectrum
           </LinkDark>
-          <LinkDark fontSize={2} mb={3} className="d-block" href="https://github.com/primer/primer/issues/new/choose">
-            <Octicon icon={Octoface} color="blue.2" size={20} verticalAlign="text-top" mr={2} />
+          <LinkDark fontSize={2} mb={3} display="block" href="https://github.com/primer/primer/issues/new/choose">
+            <Octicon icon={Octoface} size={20} verticalAlign="text-top" mr={2} />
             Share feedback on GitHub
           </LinkDark>
         </IndexGrid.Item>

--- a/src/PrimerCSS.js
+++ b/src/PrimerCSS.js
@@ -29,7 +29,7 @@ export default function PrimerCSS() {
           <ButtonOutline my={[2, 0]} href="https://github.com/primer/primer">
             GitHub
           </ButtonOutline>
-          <Text is="p" fontSize={2} mt={5} color="blue.3" className="text-mono">
+          <Text is="p" fontSize={2} mt={5} color="blue.3" fontFamily="mono">
             npm i primer@latest
           </Text>
         </IndexGrid.Item>
@@ -48,7 +48,7 @@ export default function PrimerCSS() {
               <Octicon icon={Package} height={40} verticalAlign="middle" />
             </FlexItem>
             <FlexItem>
-              <Text is="p" fontSize={2} color="blue.3" mt={1} className="text-mono">
+              <Text is="p" fontSize={2} color="blue.3" mt={1} fontFamily="mono">
                 primer
               </Text>
               <Text is="p" color="blue.2" mb={5} fontSize={3}>
@@ -61,7 +61,7 @@ export default function PrimerCSS() {
               <Octicon icon={Package} height={40} verticalAlign="middle" />
             </FlexItem>
             <FlexItem>
-              <Text is="p" fontSize={2} color="blue.3" mt={1} className="text-mono">
+              <Text is="p" fontSize={2} color="blue.3" mt={1} fontFamily="mono">
                 primer-core
               </Text>
               <Text is="p" color="blue.2" mb={5} fontSize={3}>
@@ -74,7 +74,7 @@ export default function PrimerCSS() {
               <Octicon icon={Package} height={40} verticalAlign="middle" />
             </FlexItem>
             <FlexItem>
-              <Text is="p" fontSize={2} color="blue.3" mt={1} className="text-mono">
+              <Text is="p" fontSize={2} color="blue.3" mt={1} fontFamily="mono">
                 primer-product
               </Text>
               <Text is="p" color="blue.2" mb={5} fontSize={3}>
@@ -87,7 +87,7 @@ export default function PrimerCSS() {
               <Octicon icon={Package} height={40} verticalAlign="middle" />
             </FlexItem>
             <FlexItem>
-              <Text is="p" fontSize={2} color="blue.3" mt={1} className="text-mono">
+              <Text is="p" fontSize={2} color="blue.3" mt={1} fontFamily="mono">
                 primer-marketing
               </Text>
               <Text is="p" color="blue.2" mb={5} fontSize={3}>

--- a/src/PrimerCSS.js
+++ b/src/PrimerCSS.js
@@ -1,6 +1,7 @@
 import React from 'react'
 import {Box, Heading, Text, FlexContainer, FlexItem} from '@primer/components'
-import Octicon, {Package} from '@githubprimer/octicons-react'
+import {Package} from '@githubprimer/octicons-react'
+import Octicon from './Octicon'
 import CssImage from './svg/Css.svg'
 import IndexGrid from './IndexGrid'
 import ButtonFill from './ButtonFill'

--- a/src/PrimerCSS.js
+++ b/src/PrimerCSS.js
@@ -42,7 +42,7 @@ export default function PrimerCSS() {
         </IndexGrid.Item>
       </IndexGrid>
       <Box px={5} className="container-xl">
-        <Box mx={-5} className="d-flex flex-wrap flex-items-start">
+        <FlexContainer mx={-5} flexWrap="wrap" alignItems="start">
           <FlexContainer width={[1, 6 / 12, 6 / 12]} px={5} mb={[3, 4, 4, 0]}>
             <FlexItem color="blue.3" mr={3}>
               <Octicon icon={Package} height={40} verticalAlign="middle" />
@@ -95,7 +95,7 @@ export default function PrimerCSS() {
               </Text>
             </FlexItem>
           </FlexContainer>
-        </Box>
+        </FlexContainer>
       </Box>
     </Box>
   )

--- a/src/PrimerReact.js
+++ b/src/PrimerReact.js
@@ -9,7 +9,7 @@ export default function PrimerReact() {
       <ReactIcon />
       <Heading fontSize={[4, 5]} mt={2} mb={2} color="blue.4">
         Primer Components
-        <Text fontSize={2} ml={1} className="v-align-text-top">
+        <Text fontSize={2} ml={1} css={{verticalAlign: 'text-top'}}>
           BETA
         </Text>
       </Heading>

--- a/src/template.js
+++ b/src/template.js
@@ -14,7 +14,6 @@ module.exports = ({html = '', css = '', scripts, title}) =>
   <meta charset='utf-8'>
   <meta name='viewport' content='width=device-width,initial-scale=1' />
   <link rel='stylesheet' href='https://unpkg.com/primer-layout/build/build.css' />
-  <link rel='stylesheet' href='https://unpkg.com/primer-utilities/build/build.css' />
   <link rel="apple-touch-icon" href="https://user-images.githubusercontent.com/334891/45369221-63075b00-b5b3-11e8-8ac7-7e588fe4c905.png">
   <link rel="icon" href="https://user-images.githubusercontent.com/334891/45369187-51be4e80-b5b3-11e8-8066-b06025239a79.png">
 


### PR DESCRIPTION
This is part of #11. I was able to successfully (I hope!) factor out all of our Primer CSS classes _except_ container classes from `primer-layout`. To prevent us from cheating in the future, I even removed the `<link>` to the `primer-utilities` CSS from the HTML template! 😈 

### [:eyes: Preview](https://primer-style-nix-classnames.now.sh)