### PR TITLE
Update team link in footer

### DIFF
--- a/src/OpenSource.js
+++ b/src/OpenSource.js
@@ -46,7 +46,7 @@ export default function OpenSource() {
           <Text pr={1} is="span">
             Created and maintained by GitHub&#8217;s
           </Text>
-          <LinkDark fontWeight="bold" href="https://github.com/primer/primer.style#team">
+          <LinkDark fontWeight="bold" href="https://primer.style/team">
             Design Systems team
           </LinkDark>
           <Text>.</Text>


### PR DESCRIPTION
👋 Hi, Primer team. I thought that the new ["Meet the team" page](https://primer.style/team/) might be a better a place for the "Design Systems team" link in the footer to point to.

![image](https://user-images.githubusercontent.com/4608155/46820436-070f2e00-cd3b-11e8-8f3c-47c7225e967e.png)
