### PR TITLE
Fix footer alignment

### DIFF
--- a/src/IndexGrid.js
+++ b/src/IndexGrid.js
@@ -12,12 +12,6 @@ const IndexGrid = ({alignItems, children, flexWrap, ...rest}) => {
   )
 }
 
-const Item = ({children, ...rest}) => (
-  <FlexItem width={[1, 1, 1, 6 / 12]} px={5} {...rest}>
-    {children}
-  </FlexItem>
-)
-
-IndexGrid.Item = Item
+IndexGrid.Item = props => <FlexItem width={[1, 1, 1, 6 / 12]} px={5} {...props} />
 
 export default IndexGrid

--- a/src/IndexGrid.js
+++ b/src/IndexGrid.js
@@ -2,13 +2,7 @@ import React from 'react'
 import {Box, FlexContainer, FlexItem} from '@primer/components'
 
 const IndexGrid = props => {
-  const {
-    alignItems,
-    children,
-    flexDirection,
-    flexWrap,
-    ...rest
-  } = props
+  const {alignItems, children, flexDirection, flexWrap, ...rest} = props
   const flexProps = {alignItems, flexDirection, flexWrap}
   return (
     <Box mx={'auto'} px={5} {...rest} className="container-xl">

--- a/src/IndexGrid.js
+++ b/src/IndexGrid.js
@@ -1,13 +1,16 @@
 import React from 'react'
 import {Box, FlexContainer, FlexItem} from '@primer/components'
 
-const IndexGrid = ({children, ...rest}) => (
-  <Box mx={'auto'} px={5} {...rest} className="container-xl">
-    <FlexContainer {...rest} flexWrap="wrap" alignItems="center" mx={-5}>
-      {children}
-    </FlexContainer>
-  </Box>
-)
+const IndexGrid = ({alignItems, children, flexWrap, ...rest}) => {
+  const flexProps = {alignItems, flexWrap}
+  return (
+    <Box mx={'auto'} px={5} {...rest} className="container-xl">
+      <FlexContainer {...flexProps} mx={-5}>
+        {children}
+      </FlexContainer>
+    </Box>
+  )
+}
 
 const Item = ({children, ...rest}) => (
   <FlexItem width={[1, 1, 1, 6 / 12]} px={5} {...rest}>

--- a/src/IndexGrid.js
+++ b/src/IndexGrid.js
@@ -1,8 +1,15 @@
 import React from 'react'
 import {Box, FlexContainer, FlexItem} from '@primer/components'
 
-const IndexGrid = ({alignItems, children, flexWrap, ...rest}) => {
-  const flexProps = {alignItems, flexWrap}
+const IndexGrid = props => {
+  const {
+    alignItems,
+    children,
+    flexDirection,
+    flexWrap,
+    ...rest
+  } = props
+  const flexProps = {alignItems, flexDirection, flexWrap}
   return (
     <Box mx={'auto'} px={5} {...rest} className="container-xl">
       <FlexContainer {...flexProps} mx={-5}>

--- a/src/OpenSource.js
+++ b/src/OpenSource.js
@@ -10,7 +10,7 @@ import LinkDark from './LinkDark'
 export default function OpenSource() {
   return (
     <Box bg="blue.2" pt={12} mt={6}>
-      <IndexGrid>
+      <IndexGrid alignItems="start">
         <IndexGrid.Item mb={[8, 8, 8, 0]}>
           <Heading lineHeight="1.25" color="black" mb={3} fontSize={7} fontWeight="bold">
             Open source


### PR DESCRIPTION
The IndexGrid component passes `alignItems="center"` to its FlexContainer. This modifies the component to pull `alignItems` and `flexWrap` out of its props and pass (only) those to the FlexContainer, then passes `alignItems="start"` in the OpenSource footer component.

### Before
![image](https://user-images.githubusercontent.com/113896/46830028-531a9c80-cd54-11e8-8381-43ba25f11ad9.png)

### [After](https://primer-style-fix-footer.now.sh)
![image](https://user-images.githubusercontent.com/113896/46830131-9aa12880-cd54-11e8-8070-979ee1cff2b1.png)
