### PR TITLE
Add an HSTS header for preloading at https://hstspreload.org/

### DIFF
--- a/now.json
+++ b/now.json
@@ -2,6 +2,13 @@
   "name": "primer-style",
   "type": "static",
   "static": {
-    "trailingSlash": true
+    "trailingSlash": true,
+    "headers": [{
+      "source": "*",
+      "headers": [{
+        "key": "Strict-Transport-Security",
+        "value": "max-age=63072000; includeSubDomains; preload"
+      }]
+    }]
   }
 }


### PR DESCRIPTION
Preloading `primer.style` will ensure that the site can only be accessed over HTTPS in all browsers.

Note that this a permanent commitment to serving the site (and any potential subdomains) using HTTPS.