### PR TITLE
Fix path alias deployment

### DIFF
--- a/.github/main.workflow
+++ b/.github/main.workflow
@@ -24,7 +24,7 @@ action "build" {
 }
 
 action "deploy" {
-  uses = "primer/deploy@master"
+  uses = "primer/deploy@062a7c7"
   secrets = ["GITHUB_TOKEN", "NOW_TOKEN"]
   needs = "build"
 }


### PR DESCRIPTION
This is a hotfix for [this deployment failure](https://github.com/primer/primer.style/runs/57448130), which reminded me that Now doesn't want us to run:

```sh
now alias -r rules.json primer-style.now.sh primer.style
```

...because, according to the error, "You can't supply a deployment target and target rules simultaneously." The fix should be to nix the `primer-style.now.sh` argument so that it's:

```sh
now alias -r rules.json primer.style
```

🤞 