### PR TITLE
Updating releases data, and adding primer/css to script

### DIFF
--- a/script/get-release-data
+++ b/script/get-release-data
@@ -16,7 +16,7 @@ for p in "${packages[@]}"; do
 
   for version in $versions; do
     # Skip any non-major and minor releases
-    echo $version | egrep -q '(^"[0-9]+\.[0-9]+\.[0-9]+\-|^"[^0-9])' && continue
+    echo $version | egrep -q '(^"[0-9]+\.[0-9]+\.[0-9]+\-|^"[^0-9]|^"[0-9]+\.[0-9]+\.[^0])' && continue
 
     time=$(echo $package | jq -c ".time[$version]" | sed -e "s/\"//g")
 

--- a/script/get-release-data
+++ b/script/get-release-data
@@ -2,6 +2,7 @@
 
 packages=(
   primer
+  @primer/css
   octicons
   @primer/components
 )
@@ -15,7 +16,7 @@ for p in "${packages[@]}"; do
 
   for version in $versions; do
     # Skip any non-major and minor releases
-    echo $version | egrep -q '(^"[0-9]+\.[0-9]+\.[0-9]+\-[^b]|^"[^0-9])' && continue
+    echo $version | egrep -q '(^"[0-9]+\.[0-9]+\.[0-9]+\-|^"[^0-9])' && continue
 
     time=$(echo $package | jq -c ".time[$version]" | sed -e "s/\"//g")
 
@@ -28,4 +29,4 @@ for p in "${packages[@]}"; do
   done
 done
 
-echo "[ $(echo $output | sed -e "s/,$//g") ]" > ./src/data/releases.json
+echo "[ $(echo $output | sed -e "s/,$//g") ]" | jq . > ./src/data/releases.json

--- a/src/Article.js
+++ b/src/Article.js
@@ -12,8 +12,8 @@ export const iconForType = {
 }
 
 const packageNames = {
-  '@primer/css': 'Primer',
-  primer: 'Primer',
+  '@primer/css': 'Primer CSS',
+  primer: 'Primer CSS',
   '@primer/components': 'Primer Components',
   octicons: 'Octicons'
 }

--- a/src/Article.js
+++ b/src/Article.js
@@ -12,6 +12,7 @@ export const iconForType = {
 }
 
 const packageNames = {
+  '@primer/css': 'Primer',
   primer: 'Primer',
   '@primer/components': 'Primer Components',
   octicons: 'Octicons'

--- a/src/data/releases.json
+++ b/src/data/releases.json
@@ -9,46 +9,6 @@
   },
   {
     "type": "release",
-    "title": "primer@10.10.1",
-    "name": "primer",
-    "version": "10.10.1",
-    "url": "https://github.com/primer/primer/releases/tag/v10.10.1",
-    "date": "2018-11-26T00:42:03.294Z"
-  },
-  {
-    "type": "release",
-    "title": "primer@10.10.2",
-    "name": "primer",
-    "version": "10.10.2",
-    "url": "https://github.com/primer/primer/releases/tag/v10.10.2",
-    "date": "2018-11-29T19:11:54.868Z"
-  },
-  {
-    "type": "release",
-    "title": "primer@10.10.3",
-    "name": "primer",
-    "version": "10.10.3",
-    "url": "https://github.com/primer/primer/releases/tag/v10.10.3",
-    "date": "2019-01-08T00:17:13.086Z"
-  },
-  {
-    "type": "release",
-    "title": "primer@10.10.4",
-    "name": "primer",
-    "version": "10.10.4",
-    "url": "https://github.com/primer/primer/releases/tag/v10.10.4",
-    "date": "2019-01-11T23:08:58.191Z"
-  },
-  {
-    "type": "release",
-    "title": "primer@10.10.5",
-    "name": "primer",
-    "version": "10.10.5",
-    "url": "https://github.com/primer/primer/releases/tag/v10.10.5",
-    "date": "2019-01-19T00:13:34.216Z"
-  },
-  {
-    "type": "release",
     "title": "primer@10.3.0",
     "name": "primer",
     "version": "10.3.0",
@@ -81,14 +41,6 @@
   },
   {
     "type": "release",
-    "title": "primer@10.6.1",
-    "name": "primer",
-    "version": "10.6.1",
-    "url": "https://github.com/primer/primer/releases/tag/v10.6.1",
-    "date": "2018-06-19T23:36:02.148Z"
-  },
-  {
-    "type": "release",
     "title": "primer@10.7.0",
     "name": "primer",
     "version": "10.7.0",
@@ -102,14 +54,6 @@
     "version": "10.8.0",
     "url": "https://github.com/primer/primer/releases/tag/v10.8.0",
     "date": "2018-07-27T21:46:44.976Z"
-  },
-  {
-    "type": "release",
-    "title": "primer@10.8.1",
-    "name": "primer",
-    "version": "10.8.1",
-    "url": "https://github.com/primer/primer/releases/tag/v10.8.1",
-    "date": "2018-08-03T18:53:05.802Z"
   },
   {
     "type": "release",
@@ -185,22 +129,6 @@
   },
   {
     "type": "release",
-    "title": "octicons@8.1.2",
-    "name": "octicons",
-    "version": "8.1.2",
-    "url": "https://github.com/primer/octicons/releases/tag/v8.1.2",
-    "date": "2018-11-09T18:15:33.409Z"
-  },
-  {
-    "type": "release",
-    "title": "octicons@8.1.3",
-    "name": "octicons",
-    "version": "8.1.3",
-    "url": "https://github.com/primer/octicons/releases/tag/v8.1.3",
-    "date": "2018-11-16T21:52:15.592Z"
-  },
-  {
-    "type": "release",
     "title": "octicons@8.2.0",
     "name": "octicons",
     "version": "8.2.0",
@@ -225,34 +153,10 @@
   },
   {
     "type": "release",
-    "title": "octicons@8.4.1",
-    "name": "octicons",
-    "version": "8.4.1",
-    "url": "https://github.com/primer/octicons/releases/tag/v8.4.1",
-    "date": "2019-02-08T23:26:12.021Z"
-  },
-  {
-    "type": "release",
-    "title": "octicons@8.4.2",
-    "name": "octicons",
-    "version": "8.4.2",
-    "url": "https://github.com/primer/octicons/releases/tag/v8.4.2",
-    "date": "2019-02-20T17:38:16.461Z"
-  },
-  {
-    "type": "release",
     "title": "@primer/components@10.0.0",
     "name": "@primer/components",
     "version": "10.0.0",
     "url": "https://github.com/primer/components/releases/tag/v10.0.0",
     "date": "2019-02-11T21:22:55.795Z"
-  },
-  {
-    "type": "release",
-    "title": "@primer/components@10.0.1",
-    "name": "@primer/components",
-    "version": "10.0.1",
-    "url": "https://github.com/primer/components/releases/tag/v10.0.1",
-    "date": "2019-02-19T08:11:33.058Z"
   }
 ]

--- a/src/data/releases.json
+++ b/src/data/releases.json
@@ -1,1 +1,258 @@
-[ { "type": "release", "title": "primer@10.3.0", "name": "primer", "version": "10.3.0", "url": "https://github.com/primer/primer/releases/tag/v10.3.0", "date": "2018-01-18T00:44:14.394Z" }, { "type": "release", "title": "primer@10.4.0", "name": "primer", "version": "10.4.0", "url": "https://github.com/primer/primer/releases/tag/v10.4.0", "date": "2018-03-20T19:55:48.088Z" }, { "type": "release", "title": "primer@10.5.0", "name": "primer", "version": "10.5.0", "url": "https://github.com/primer/primer/releases/tag/v10.5.0", "date": "2018-05-10T23:09:05.103Z" }, { "type": "release", "title": "primer@10.6.0", "name": "primer", "version": "10.6.0", "url": "https://github.com/primer/primer/releases/tag/v10.6.0", "date": "2018-06-14T15:52:20.070Z" }, { "type": "release", "title": "primer@10.6.1", "name": "primer", "version": "10.6.1", "url": "https://github.com/primer/primer/releases/tag/v10.6.1", "date": "2018-06-19T23:36:02.148Z" }, { "type": "release", "title": "primer@10.7.0", "name": "primer", "version": "10.7.0", "url": "https://github.com/primer/primer/releases/tag/v10.7.0", "date": "2018-07-02T18:04:02.767Z" }, { "type": "release", "title": "primer@10.8.0", "name": "primer", "version": "10.8.0", "url": "https://github.com/primer/primer/releases/tag/v10.8.0", "date": "2018-07-27T21:46:44.976Z" }, { "type": "release", "title": "primer@10.8.1", "name": "primer", "version": "10.8.1", "url": "https://github.com/primer/primer/releases/tag/v10.8.1", "date": "2018-08-03T18:53:05.802Z" }, { "type": "release", "title": "primer@10.9.0", "name": "primer", "version": "10.9.0", "url": "https://github.com/primer/primer/releases/tag/v10.9.0", "date": "2018-10-23T20:06:33.994Z" }, { "type": "release", "title": "octicons@7.1.0", "name": "octicons", "version": "7.1.0", "url": "https://github.com/primer/octicons/releases/tag/v7.1.0", "date": "2018-01-05T21:37:31.529Z" }, { "type": "release", "title": "octicons@7.2.0", "name": "octicons", "version": "7.2.0", "url": "https://github.com/primer/octicons/releases/tag/v7.2.0", "date": "2018-03-23T21:29:42.073Z" }, { "type": "release", "title": "octicons@7.3.0", "name": "octicons", "version": "7.3.0", "url": "https://github.com/primer/octicons/releases/tag/v7.3.0", "date": "2018-05-09T18:09:26.530Z" }, { "type": "release", "title": "octicons@7.4.0", "name": "octicons", "version": "7.4.0", "url": "https://github.com/primer/octicons/releases/tag/v7.4.0", "date": "2018-07-09T23:10:40.268Z" }, { "type": "release", "title": "octicons@8.0.0", "name": "octicons", "version": "8.0.0", "url": "https://github.com/primer/octicons/releases/tag/v8.0.0", "date": "2018-07-13T00:07:41.841Z" }, { "type": "release", "title": "octicons@8.1.0", "name": "octicons", "version": "8.1.0", "url": "https://github.com/primer/octicons/releases/tag/v8.1.0", "date": "2018-08-30T18:59:37.740Z" }, { "type": "release", "title": "@primer/components@2.0.4-beta", "name": "@primer/components", "version": "2.0.4-beta", "url": "https://github.com/primer/components/releases/tag/v2.0.4-beta", "date": "2018-09-21T19:56:55.095Z" }, { "type": "release", "title": "@primer/components@3.0.0-beta", "name": "@primer/components", "version": "3.0.0-beta", "url": "https://github.com/primer/components/releases/tag/v3.0.0-beta", "date": "2018-09-28T19:14:49.307Z" }, { "type": "release", "title": "@primer/components@3.0.1-beta", "name": "@primer/components", "version": "3.0.1-beta", "url": "https://github.com/primer/components/releases/tag/v3.0.1-beta", "date": "2018-10-03T20:14:22.486Z" }, { "type": "release", "title": "@primer/components@3.0.2-beta", "name": "@primer/components", "version": "3.0.2-beta", "url": "https://github.com/primer/components/releases/tag/v3.0.2-beta", "date": "2018-10-05T18:53:52.459Z" }, { "type": "release", "title": "@primer/components@3.0.3-beta", "name": "@primer/components", "version": "3.0.3-beta", "url": "https://github.com/primer/components/releases/tag/v3.0.3-beta", "date": "2018-10-10T20:15:08.934Z" }, { "type": "release", "title": "@primer/components@4.0.0-beta", "name": "@primer/components", "version": "4.0.0-beta", "url": "https://github.com/primer/components/releases/tag/v4.0.0-beta", "date": "2018-10-12T20:37:51.899Z" }, { "type": "release", "title": "@primer/components@5.0.0-beta", "name": "@primer/components", "version": "5.0.0-beta", "url": "https://github.com/primer/components/releases/tag/v5.0.0-beta", "date": "2018-10-26T18:06:39.617Z" }, { "type": "release", "title": "@primer/components@6.0.0-beta", "name": "@primer/components", "version": "6.0.0-beta", "url": "https://github.com/primer/components/releases/tag/v6.0.0-beta", "date": "2018-11-02T21:16:59.417Z" } ]
+[
+  {
+    "type": "release",
+    "title": "primer@10.10.0",
+    "name": "primer",
+    "version": "10.10.0",
+    "url": "https://github.com/primer/primer/releases/tag/v10.10.0",
+    "date": "2018-11-20T00:06:06.038Z"
+  },
+  {
+    "type": "release",
+    "title": "primer@10.10.1",
+    "name": "primer",
+    "version": "10.10.1",
+    "url": "https://github.com/primer/primer/releases/tag/v10.10.1",
+    "date": "2018-11-26T00:42:03.294Z"
+  },
+  {
+    "type": "release",
+    "title": "primer@10.10.2",
+    "name": "primer",
+    "version": "10.10.2",
+    "url": "https://github.com/primer/primer/releases/tag/v10.10.2",
+    "date": "2018-11-29T19:11:54.868Z"
+  },
+  {
+    "type": "release",
+    "title": "primer@10.10.3",
+    "name": "primer",
+    "version": "10.10.3",
+    "url": "https://github.com/primer/primer/releases/tag/v10.10.3",
+    "date": "2019-01-08T00:17:13.086Z"
+  },
+  {
+    "type": "release",
+    "title": "primer@10.10.4",
+    "name": "primer",
+    "version": "10.10.4",
+    "url": "https://github.com/primer/primer/releases/tag/v10.10.4",
+    "date": "2019-01-11T23:08:58.191Z"
+  },
+  {
+    "type": "release",
+    "title": "primer@10.10.5",
+    "name": "primer",
+    "version": "10.10.5",
+    "url": "https://github.com/primer/primer/releases/tag/v10.10.5",
+    "date": "2019-01-19T00:13:34.216Z"
+  },
+  {
+    "type": "release",
+    "title": "primer@10.3.0",
+    "name": "primer",
+    "version": "10.3.0",
+    "url": "https://github.com/primer/primer/releases/tag/v10.3.0",
+    "date": "2018-01-18T00:44:14.394Z"
+  },
+  {
+    "type": "release",
+    "title": "primer@10.4.0",
+    "name": "primer",
+    "version": "10.4.0",
+    "url": "https://github.com/primer/primer/releases/tag/v10.4.0",
+    "date": "2018-03-20T19:55:48.088Z"
+  },
+  {
+    "type": "release",
+    "title": "primer@10.5.0",
+    "name": "primer",
+    "version": "10.5.0",
+    "url": "https://github.com/primer/primer/releases/tag/v10.5.0",
+    "date": "2018-05-10T23:09:05.103Z"
+  },
+  {
+    "type": "release",
+    "title": "primer@10.6.0",
+    "name": "primer",
+    "version": "10.6.0",
+    "url": "https://github.com/primer/primer/releases/tag/v10.6.0",
+    "date": "2018-06-14T15:52:20.070Z"
+  },
+  {
+    "type": "release",
+    "title": "primer@10.6.1",
+    "name": "primer",
+    "version": "10.6.1",
+    "url": "https://github.com/primer/primer/releases/tag/v10.6.1",
+    "date": "2018-06-19T23:36:02.148Z"
+  },
+  {
+    "type": "release",
+    "title": "primer@10.7.0",
+    "name": "primer",
+    "version": "10.7.0",
+    "url": "https://github.com/primer/primer/releases/tag/v10.7.0",
+    "date": "2018-07-02T18:04:02.767Z"
+  },
+  {
+    "type": "release",
+    "title": "primer@10.8.0",
+    "name": "primer",
+    "version": "10.8.0",
+    "url": "https://github.com/primer/primer/releases/tag/v10.8.0",
+    "date": "2018-07-27T21:46:44.976Z"
+  },
+  {
+    "type": "release",
+    "title": "primer@10.8.1",
+    "name": "primer",
+    "version": "10.8.1",
+    "url": "https://github.com/primer/primer/releases/tag/v10.8.1",
+    "date": "2018-08-03T18:53:05.802Z"
+  },
+  {
+    "type": "release",
+    "title": "primer@10.9.0",
+    "name": "primer",
+    "version": "10.9.0",
+    "url": "https://github.com/primer/primer/releases/tag/v10.9.0",
+    "date": "2018-10-23T20:06:33.994Z"
+  },
+  {
+    "type": "release",
+    "title": "primer@11.0.0",
+    "name": "primer",
+    "version": "11.0.0",
+    "url": "https://github.com/primer/primer/releases/tag/v11.0.0",
+    "date": "2019-01-26T00:01:41.123Z"
+  },
+  {
+    "type": "release",
+    "title": "@primer/css@12.0.0",
+    "name": "@primer/css",
+    "version": "12.0.0",
+    "url": "https://github.com/primer/css/releases/tag/v12.0.0",
+    "date": "2019-02-19T21:40:13.059Z"
+  },
+  {
+    "type": "release",
+    "title": "octicons@7.1.0",
+    "name": "octicons",
+    "version": "7.1.0",
+    "url": "https://github.com/primer/octicons/releases/tag/v7.1.0",
+    "date": "2018-01-05T21:37:31.529Z"
+  },
+  {
+    "type": "release",
+    "title": "octicons@7.2.0",
+    "name": "octicons",
+    "version": "7.2.0",
+    "url": "https://github.com/primer/octicons/releases/tag/v7.2.0",
+    "date": "2018-03-23T21:29:42.073Z"
+  },
+  {
+    "type": "release",
+    "title": "octicons@7.3.0",
+    "name": "octicons",
+    "version": "7.3.0",
+    "url": "https://github.com/primer/octicons/releases/tag/v7.3.0",
+    "date": "2018-05-09T18:09:26.530Z"
+  },
+  {
+    "type": "release",
+    "title": "octicons@7.4.0",
+    "name": "octicons",
+    "version": "7.4.0",
+    "url": "https://github.com/primer/octicons/releases/tag/v7.4.0",
+    "date": "2018-07-09T23:10:40.268Z"
+  },
+  {
+    "type": "release",
+    "title": "octicons@8.0.0",
+    "name": "octicons",
+    "version": "8.0.0",
+    "url": "https://github.com/primer/octicons/releases/tag/v8.0.0",
+    "date": "2018-07-13T00:07:41.841Z"
+  },
+  {
+    "type": "release",
+    "title": "octicons@8.1.0",
+    "name": "octicons",
+    "version": "8.1.0",
+    "url": "https://github.com/primer/octicons/releases/tag/v8.1.0",
+    "date": "2018-08-30T18:59:37.740Z"
+  },
+  {
+    "type": "release",
+    "title": "octicons@8.1.2",
+    "name": "octicons",
+    "version": "8.1.2",
+    "url": "https://github.com/primer/octicons/releases/tag/v8.1.2",
+    "date": "2018-11-09T18:15:33.409Z"
+  },
+  {
+    "type": "release",
+    "title": "octicons@8.1.3",
+    "name": "octicons",
+    "version": "8.1.3",
+    "url": "https://github.com/primer/octicons/releases/tag/v8.1.3",
+    "date": "2018-11-16T21:52:15.592Z"
+  },
+  {
+    "type": "release",
+    "title": "octicons@8.2.0",
+    "name": "octicons",
+    "version": "8.2.0",
+    "url": "https://github.com/primer/octicons/releases/tag/v8.2.0",
+    "date": "2018-12-04T21:08:39.238Z"
+  },
+  {
+    "type": "release",
+    "title": "octicons@8.3.0",
+    "name": "octicons",
+    "version": "8.3.0",
+    "url": "https://github.com/primer/octicons/releases/tag/v8.3.0",
+    "date": "2019-01-09T21:20:09.576Z"
+  },
+  {
+    "type": "release",
+    "title": "octicons@8.4.0",
+    "name": "octicons",
+    "version": "8.4.0",
+    "url": "https://github.com/primer/octicons/releases/tag/v8.4.0",
+    "date": "2019-02-08T19:57:16.936Z"
+  },
+  {
+    "type": "release",
+    "title": "octicons@8.4.1",
+    "name": "octicons",
+    "version": "8.4.1",
+    "url": "https://github.com/primer/octicons/releases/tag/v8.4.1",
+    "date": "2019-02-08T23:26:12.021Z"
+  },
+  {
+    "type": "release",
+    "title": "octicons@8.4.2",
+    "name": "octicons",
+    "version": "8.4.2",
+    "url": "https://github.com/primer/octicons/releases/tag/v8.4.2",
+    "date": "2019-02-20T17:38:16.461Z"
+  },
+  {
+    "type": "release",
+    "title": "@primer/components@10.0.0",
+    "name": "@primer/components",
+    "version": "10.0.0",
+    "url": "https://github.com/primer/components/releases/tag/v10.0.0",
+    "date": "2019-02-11T21:22:55.795Z"
+  },
+  {
+    "type": "release",
+    "title": "@primer/components@10.0.1",
+    "name": "@primer/components",
+    "version": "10.0.1",
+    "url": "https://github.com/primer/components/releases/tag/v10.0.1",
+    "date": "2019-02-19T08:11:33.058Z"
+  }
+]


### PR DESCRIPTION
The releases in "What's new" https://primer.style/news were out of date. So I updated the data by running `script/get-release-data`

I also updated the script to incorporate the new package name `@primer/css` for 12. And since primer components is out of beta, I stoped including beta releases. Also pretty printing the data file

