### PR TITLE
use primer/deploy@v2.0.0

### DIFF
--- a/.github/main.workflow
+++ b/.github/main.workflow
@@ -24,7 +24,7 @@ action "build" {
 }
 
 action "deploy" {
-  uses = "primer/deploy@062a7c7"
+  uses = "primer/deploy@v2.0.0"
   secrets = ["GITHUB_TOKEN", "NOW_TOKEN"]
   needs = "build"
 }


### PR DESCRIPTION
Not much difference between the SHA and v2.0.0, but I figured it would be good to get all our repos on the right version.