### PR TITLE
Update development contributing docs

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -10,10 +10,7 @@ This site is built with [Primer React components][components] and [x0].
 To start up your local dev environment, run:
 
 1. `npm install` to install all the Node dependencies
-2. `npm run dev` to start the dev server
-3. `npm run build` to build the static site
-4. `npm start` to serve the static site
-
+2. `npm start` to run the app in development mode
 
 ## Deployment
 This site is deployed on [Now] and mapped to the `primer.style` domain. With the Now CLI installed globally (and authenticated), you should be able deploy the site by running:

--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -12,6 +12,8 @@ To start up your local dev environment, run:
 1. `npm install` to install all the Node dependencies
 2. `npm start` to run the app in development mode
 
+Additionally, you can run `npm run now-build` to build the static site, and `npm run now-start` to run the static site on your local environment. This can be helpful for debugging build issues.
+
 ## Deployment
 This site is deployed on [Now] and mapped to the `primer.style` domain. With the Now CLI installed globally (and authenticated), you should be able deploy the site by running:
 

--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -14,6 +14,11 @@ To start up your local dev environment, run:
 
 Additionally, you can run `npm run now-build` to build the static site, and `npm run now-start` to run the static site on your local environment. This can be helpful for debugging build issues.
 
+We use the [React configuration](https://github.com/github/eslint-plugin-github/blob/master/lib/configs/react.js) from [GitHub's eslint plugin](https://github.com/github/eslint-plugin-github) to lint our JavaScript. To check your work before pushing, run:
+```
+npm run lint
+```
+
 ## Deployment
 This site is deployed on [Now] and mapped to the `primer.style` domain. With the Now CLI installed globally (and authenticated), you should be able deploy the site by running:
 


### PR DESCRIPTION
Removes obsolete npm scripts `npm run dev` and `npm run build` from the contributing docs which are no longer relevant since the update in https://github.com/primer/primer.style/pull/124 which makes the switch to using _Next_.