### PR TITLE
Update documentation links

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,19 +1,25 @@
 <p align="center">
-<img width="300px" src="readme-style.png">
+  <img width="300px" src="readme-style.png">
+</p>
 
 <p align="center">
-<h3 align="center">Primer.style</h3>
+  <h3 align="center">Primer.style</h3>
+</p>
 
 <p align="center">
-<a href="https://styleguide.github.com/primer">Styleguide</a>
-    ·
-    <a href="https://github.com/primer">Primer org</a>
-    ·
-    <a href="https://spectrum.chat/primer">Community</a>
+  <a href="https://primer.style/css">Documentation</a>
+  ·
+  <a href="https://primer.style/components">Components</a>
+  ·
+  <a href="https://github.com/primer">Primer org</a>
+  ·
+  <a href="https://spectrum.chat/primer">Community</a>
+</p>
 
 <p align="center">Primer is GitHub's design system.<br /> The <a href="https://primer.style/">primer.style</a> website will, over time, be the hub from which all Primer web properties are linked from.
-  
-  ---
+</p>
+
+---
   
 #### Up-coming work & contributing
   

--- a/README.md
+++ b/README.md
@@ -7,8 +7,6 @@
 </p>
 
 <p align="center">
-  <a href="https://primer.style/css">Documentation</a>
-  ·
   <a href="https://primer.style/components">Components</a>
   ·
   <a href="https://github.com/primer">Primer org</a>

--- a/src/Hero.js
+++ b/src/Hero.js
@@ -25,8 +25,12 @@ export default function Hero() {
             Resources, tooling, and design guidelines for building interfaces with GitHub’s design system
           </Text>
           <Text fontFamily="mono" as="p" color="blue.3" mt={5}>
-            <LinkLight fontSize={[0, 1, 2]} href="https://styleguide.github.com/primer/">
-              Style guide
+            <LinkLight fontSize={[0, 1, 2]} href="https://primer.style/css/">
+              Documentation
+            </LinkLight>{' '}
+            ・
+            <LinkLight ml={2} fontSize={[0, 1, 2]} href="https://primer.style/components/">
+              Components
             </LinkLight>{' '}
             ・
             <LinkLight ml={2} fontSize={[0, 1, 2]} href="https://spectrum.chat/primer">

--- a/src/Hero.js
+++ b/src/Hero.js
@@ -25,8 +25,8 @@ export default function Hero() {
             Resources, tooling, and design guidelines for building interfaces with GitHub’s design system
           </Text>
           <Text fontFamily="mono" as="p" color="blue.3" mt={5}>
-            <LinkLight fontSize={[0, 1, 2]} href="https://primer.style/css/">
-              Documentation
+            <LinkLight fontSize={[0, 1, 2]} href="https://primer.style/team">
+              Team
             </LinkLight>{' '}
             ・
             <LinkLight ml={2} fontSize={[0, 1, 2]} href="https://primer.style/components/">

--- a/src/OpenSource.js
+++ b/src/OpenSource.js
@@ -35,7 +35,7 @@ export default function OpenSource() {
             <StyledOcticon icon={SpectrumIcon} size={20} verticalAlign="top" mr={2} />
             Chat with us in Spectrum
           </LinkDark>
-          <LinkDark fontSize={2} mb={3} display="block" href="https://github.com/primer/primer/issues/new/choose">
+          <LinkDark fontSize={2} mb={3} display="block" href="https://github.com/primer/css/issues/new/choose">
             <StyledOcticon icon={Octoface} size={20} verticalAlign="text-top" mr={2} />
             Share feedback on GitHub
           </LinkDark>

--- a/src/PrimerCSS.js
+++ b/src/PrimerCSS.js
@@ -22,10 +22,10 @@ export default function PrimerCSS() {
           <Text as="p" color="blue.2" mb={5} fontSize={3}>
             Styles can be mixed and matched to achieve many different layouts, independent of their location.
           </Text>
-          <ButtonFill my={[2, 0]} mr={2} href="https://styleguide.github.com/primer/">
+          <ButtonFill my={[2, 0]} mr={2} href="https://primer.style/css/">
             Documentation
           </ButtonFill>
-          <ButtonOutline my={[2, 0]} href="https://github.com/primer/primer">
+          <ButtonOutline my={[2, 0]} href="https://github.com/primer/css">
             GitHub
           </ButtonOutline>
           <Text as="p" fontSize={2} mt={5} color="blue.3" fontFamily="mono">


### PR DESCRIPTION
This will update documentation links which currently point to obsolete documentation. This could also move the _Team_ link along with the rest of the links inside the hero section (see https://github.com/primer/primer.style/issues/123#issuecomment-493263134). /cc @broccolini 

Fix https://github.com/primer/primer.style/issues/123.

| Before        | After          |
| ------------- |:-------------:|
| ![image](https://user-images.githubusercontent.com/120486/58320504-70eccb80-7e24-11e9-8def-acc4d044ce16.png) | ![image](https://user-images.githubusercontent.com/120486/58320485-67636380-7e24-11e9-908f-c116ab44deb4.png) |