### PR TITLE
Remove `<title>` tag from `_document.js`

### DIFF
--- a/pages/_document.js
+++ b/pages/_document.js
@@ -18,7 +18,6 @@ export default class MyDocument extends Document {
     return (
       <html lang="en">
         <Head>
-          <title>Primer Design System</title>
           <meta name="keywords" content="Design System" />
           <meta property="og:article:author" content="GitHub Design Systems team" />
           <meta property="og:title" content="Primer" />


### PR DESCRIPTION
This will remove the `<title>` tag from `pages/_document.js`.

During `npm start` the following warning message showed up:

```sh
Warning: <title> should not be used in _document.js's <Head>. https://err.sh/next.js/no-document-title
```

The `<title>` tag was added in https://github.com/primer/primer.style/pull/127 but this only needed the tag in `pages/_app.js`. See documentation in https://err.sh/next.js/no-document-title.