### PR TITLE
Fix white gap on the bottom of the team page

### DIFF
--- a/pages/team/index.js
+++ b/pages/team/index.js
@@ -20,7 +20,7 @@ const getMemberContent = teamMembers => {
 }
 
 const TeamIndex = () => (
-  <Box className="container-xl overflow-hidden" pt={8} px={5}>
+  <Flex className="container-xl overflow-hidden" flexDirection="column" pt={8} px={5}>
     <Flex
       justifyContent="space-between"
       flexDirection={['column-reverse', 'column-reverse', 'column-reverse', 'row']}
@@ -55,7 +55,7 @@ const TeamIndex = () => (
       Alumni
     </Heading>
     {getMemberContent(alumni)}
-  </Box>
+  </Flex>
 )
 
 export default TeamIndex


### PR DESCRIPTION
This pull fixes the awkward white gap on the bottom of the team page by making the page container a flex container. 

**Before:**

![image](https://user-images.githubusercontent.com/4608155/58683262-a9127380-8328-11e9-88e6-092c38d1a7e9.png)

**After:**

![image](https://user-images.githubusercontent.com/4608155/58683382-1b835380-8329-11e9-99c0-214614825bc5.png)


