### PR TITLE
Remove trailing slash character on components link

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -41,7 +41,7 @@ Now's [path alias] feature allows us to serve multiple apps under a single domai
 #### Path alias tips and tricks
 Because of the way that Now's path alias feature works, separate apps need to be configured to serve all of their URLs under the same path as they're aliased to here. In other words, an app aliased to `/alias/**` will need to serve all of its content from `/alias/` rather than `/`. For Next.js apps, this means nesting all of your page content in `pages/<alias>/`. Serving static assets is trickier; you can see how we did it for [the components site][components] in [this pull request](https://github.com/primer/components/pull/238).
 
-[components]: https://primer.style/components/
+[components]: https://primer.style/components
 [Now]: https://zeit.co/now
 [Now GitHub app]: https://github.com/apps/now
 [path alias]: https://zeit.co/docs/features/path-aliases

--- a/src/Hero.js
+++ b/src/Hero.js
@@ -29,7 +29,7 @@ export default function Hero() {
               Team
             </LinkLight>{' '}
             ・
-            <LinkLight ml={2} fontSize={[0, 1, 2]} href="https://primer.style/components/">
+            <LinkLight ml={2} fontSize={[0, 1, 2]} href="https://primer.style/components">
               Components
             </LinkLight>{' '}
             ・


### PR DESCRIPTION
Following the changes in https://github.com/primer/primer.style/pull/131, and more specifically the addition in https://github.com/gtsiolis/primer.style/commit/067a8f8d5315a93e322c155fcc1b44a5e375f84b#diff-c597a4ae790d5db22417a1f6d19b0a04R32, this will remove the trailing slash character `/` on components link which now causes a 404 error.

Alternatively, or additionally, this could be fixed by allowing the trailing slash character `/` on such URLs.