### PR TITLE
Fill vertical space at the bottom of `/news`

### DIFF
--- a/pages/news/index.js
+++ b/pages/news/index.js
@@ -7,7 +7,7 @@ import NewsImage from '../news-illo.svg'
 
 const NewsIndex = () => {
   return (
-    <Box className="container-xl overflow-hidden" pt={8} px={5}>
+    <Flex className="container-xl overflow-hidden" flexDirection="column" pt={8} px={5}>
       <Flex
         justifyContent="space-between"
         flexDirection={['column-reverse', 'column-reverse', 'column-reverse', 'row']}
@@ -30,7 +30,7 @@ const NewsIndex = () => {
         </Relative>
       </Flex>
       <NewsList items={whatsNew} />
-    </Box>
+    </Flex>
   )
 }
 


### PR DESCRIPTION
This will fill the vertical space at the bottom of `/news`. Thanks @colebemis for inspiring this in https://github.com/primer/primer.style/pull/137.

Fix #69

| Before        | After          |
| ------------- |:-------------:|
| ![image](https://user-images.githubusercontent.com/120486/58691747-87030a80-8395-11e9-87e5-222555ee665d.png) | ![image](https://user-images.githubusercontent.com/120486/58691755-8b2f2800-8395-11e9-9193-0b8cac814308.png) |