### PR TITLE
Update the copyright year 📅

### DIFF
--- a/src/CopyrightYear.js
+++ b/src/CopyrightYear.js
@@ -1,0 +1,4 @@
+const today = new Date();
+const CopyrightYear = today.getFullYear()
+
+export default CopyrightYear

--- a/src/CopyrightYear.js
+++ b/src/CopyrightYear.js
@@ -1,4 +1,0 @@
-const today = new Date()
-const CopyrightYear = today.getFullYear()
-
-export default CopyrightYear

--- a/src/CopyrightYear.js
+++ b/src/CopyrightYear.js
@@ -1,4 +1,4 @@
-const today = new Date();
+const today = new Date()
 const CopyrightYear = today.getFullYear()
 
 export default CopyrightYear

--- a/src/OpenSource.js
+++ b/src/OpenSource.js
@@ -6,6 +6,7 @@ import TwitterIcon from './TwitterIcon'
 import SpectrumIcon from './SpectrumIcon'
 import IndexGrid from './IndexGrid'
 import LinkDark from './LinkDark'
+import CopyrightYear from './CopyrightYear'
 
 export default function OpenSource() {
   return (
@@ -58,7 +59,7 @@ export default function OpenSource() {
             Design Systems team
           </LinkDark>
           <Text>.</Text>
-          <Text as="p">Copyright GitHub 2018.</Text>
+          <Text as="p">Copyright GitHub {CopyrightYear}.</Text>
         </BorderBox>
       </Box>
     </Box>

--- a/src/OpenSource.js
+++ b/src/OpenSource.js
@@ -6,7 +6,6 @@ import TwitterIcon from './TwitterIcon'
 import SpectrumIcon from './SpectrumIcon'
 import IndexGrid from './IndexGrid'
 import LinkDark from './LinkDark'
-import CopyrightYear from './CopyrightYear'
 
 export default function OpenSource() {
   return (

--- a/src/OpenSource.js
+++ b/src/OpenSource.js
@@ -59,7 +59,7 @@ export default function OpenSource() {
             Design Systems team
           </LinkDark>
           <Text>.</Text>
-          <Text as="p">Copyright GitHub {CopyrightYear}.</Text>
+          <Text as="p">Copyright GitHub {new Date().getFullYear()}.</Text>
         </BorderBox>
       </Box>
     </Box>


### PR DESCRIPTION
I was reading docs happily today (<3) when I went to the homepage and something caught my eye! 🙈 

![Screen Shot 2019-06-06 at 11 53 13 PM](https://user-images.githubusercontent.com/221550/59080371-5996ef00-88b6-11e9-8abc-61566d2d8a6b.png)

Instead of adding `2019` in plaintext, I figured I should JS-ify it. Let me know if the approach needs fixing!
