### PR TITLE
Upgrading to Octicons@9.0.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1001,14 +1001,6 @@
       "resolved": "https://registry.npmjs.org/@emotion/unitless/-/unitless-0.7.3.tgz",
       "integrity": "sha512-4zAPlpDEh2VwXswwr/t8xGNDGg8RQiPxtxZ3qQEXyQsBV39ptTdESCjuBvGze1nLMVrxmTIKmnO/nAV8Tqjjzg=="
     },
-    "@githubprimer/octicons-react": {
-      "version": "8.1.0",
-      "resolved": "https://registry.npmjs.org/@githubprimer/octicons-react/-/octicons-react-8.1.0.tgz",
-      "integrity": "sha512-BvUQWjXHTd6bFcibtFclmNrXd7FWnN3csvY7gZfPPr7plcHHPdgKoLNy1CwsCTVsNLL2jM4FkIvemBoFZeZn5w==",
-      "requires": {
-        "prop-types": "^15.6.1"
-      }
-    },
     "@mrmlnc/readdir-enhanced": {
       "version": "2.2.1",
       "resolved": "https://registry.npmjs.org/@mrmlnc/readdir-enhanced/-/readdir-enhanced-2.2.1.tgz",
@@ -1948,6 +1940,14 @@
         "val-loader": "^1.1.1"
       }
     },
+    "@primer/octicons-react": {
+      "version": "9.0.0",
+      "resolved": "https://registry.npmjs.org/@primer/octicons-react/-/octicons-react-9.0.0.tgz",
+      "integrity": "sha512-pzklnlyRWugBjejAcp5OPJ6RclMJzDxXk95FyuxzFT0dMg8GHWq0oJbrIkX3b1rWiF04jKkHk7r8oKbKLwcF+Q==",
+      "requires": {
+        "prop-types": "^15.6.1"
+      }
+    },
     "@svgr/core": {
       "version": "2.4.1",
       "resolved": "https://registry.npmjs.org/@svgr/core/-/core-2.4.1.tgz",
@@ -2783,7 +2783,7 @@
     },
     "babel-plugin-syntax-jsx": {
       "version": "6.18.0",
-      "resolved": "https://registry.npmjs.org/babel-plugin-syntax-jsx/-/babel-plugin-syntax-jsx-6.18.0.tgz",
+      "resolved": "http://registry.npmjs.org/babel-plugin-syntax-jsx/-/babel-plugin-syntax-jsx-6.18.0.tgz",
       "integrity": "sha1-CvMqmm4Tyno/1QaeYtew9Y0NiUY="
     },
     "babel-plugin-transform-react-remove-prop-types": {
@@ -3702,13 +3702,13 @@
       "dependencies": {
         "node-fetch": {
           "version": "2.1.2",
-          "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.1.2.tgz",
+          "resolved": "http://registry.npmjs.org/node-fetch/-/node-fetch-2.1.2.tgz",
           "integrity": "sha1-q4hOjn5X44qUR1POxwb3iNF2i7U=",
           "dev": true
         },
         "whatwg-fetch": {
           "version": "2.0.4",
-          "resolved": "https://registry.npmjs.org/whatwg-fetch/-/whatwg-fetch-2.0.4.tgz",
+          "resolved": "http://registry.npmjs.org/whatwg-fetch/-/whatwg-fetch-2.0.4.tgz",
           "integrity": "sha512-dcQ1GWpOD/eEQ97k66aiEVpNnapVj90/+R+SXTPYGHpYBBypfKJEQjLrvMZ7YXbKm21gXd4NcuxUTjiv1YtLng==",
           "dev": true
         }
@@ -5521,7 +5521,8 @@
         "ansi-regex": {
           "version": "2.1.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "aproba": {
           "version": "1.2.0",
@@ -5542,12 +5543,14 @@
         "balanced-match": {
           "version": "1.0.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -5562,17 +5565,20 @@
         "code-point-at": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "concat-map": {
           "version": "0.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "console-control-strings": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -5689,7 +5695,8 @@
         "inherits": {
           "version": "2.0.3",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "ini": {
           "version": "1.3.5",
@@ -5701,6 +5708,7 @@
           "version": "1.0.0",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -5715,6 +5723,7 @@
           "version": "3.0.4",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
@@ -5722,12 +5731,14 @@
         "minimist": {
           "version": "0.0.8",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "minipass": {
           "version": "2.3.5",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.2",
             "yallist": "^3.0.0"
@@ -5746,6 +5757,7 @@
           "version": "0.5.1",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -5826,7 +5838,8 @@
         "number-is-nan": {
           "version": "1.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -5838,6 +5851,7 @@
           "version": "1.4.0",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -5923,7 +5937,8 @@
         "safe-buffer": {
           "version": "5.1.2",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "safer-buffer": {
           "version": "2.1.2",
@@ -5959,6 +5974,7 @@
           "version": "1.0.2",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -5978,6 +5994,7 @@
           "version": "3.0.1",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -6021,12 +6038,14 @@
         "wrappy": {
           "version": "1.0.2",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "yallist": {
           "version": "3.0.3",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         }
       }
     },
@@ -7851,7 +7870,7 @@
     },
     "mkdirp": {
       "version": "0.5.1",
-      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
+      "resolved": "http://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
       "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
       "dev": true,
       "requires": {
@@ -10131,7 +10150,7 @@
       "dependencies": {
         "kind-of": {
           "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-2.0.1.tgz",
+          "resolved": "http://registry.npmjs.org/kind-of/-/kind-of-2.0.1.tgz",
           "integrity": "sha1-AY7HpM5+OobLkUG+UZ0kyPqpgbU=",
           "dev": true,
           "requires": {
@@ -10803,7 +10822,7 @@
     },
     "table": {
       "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/table/-/table-4.0.3.tgz",
+      "resolved": "http://registry.npmjs.org/table/-/table-4.0.3.tgz",
       "integrity": "sha512-S7rnFITmBH1EnyKcvxBh1LjYeQMmnZtCXSEbHcH6S0NoKit24ZuFO/T1vDcLdYsLQkM188PVVhQmzKIuThNkKg==",
       "dev": true,
       "requires": {
@@ -11970,7 +11989,7 @@
     },
     "wrap-ansi": {
       "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-2.1.0.tgz",
+      "resolved": "http://registry.npmjs.org/wrap-ansi/-/wrap-ansi-2.1.0.tgz",
       "integrity": "sha1-2Pw9KE3QV5T+hJc8rs3Rz4JP3YU=",
       "dev": true,
       "requires": {

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "lint": "eslint src pages"
   },
   "dependencies": {
-    "@githubprimer/octicons-react": "8.1.0",
+    "@primer/octicons-react": "9.0.0",
     "primer-primitives": "1.0.2",
     "prop-types": "15.6.2",
     "react-markdown": "4.0.1",

--- a/src/Article.js
+++ b/src/Article.js
@@ -1,7 +1,7 @@
 import React from 'react'
 import PropTypes from 'prop-types'
 import {Box, Link, Text, Heading, StyledOcticon} from '@primer/components'
-import {Note, Tag, LinkExternal, Megaphone, Broadcast} from '@githubprimer/octicons-react'
+import {Note, Tag, LinkExternal, Megaphone, Broadcast} from '@primer/octicons-react'
 
 export const iconForType = {
   article: Note,

--- a/src/HiringPromo.js
+++ b/src/HiringPromo.js
@@ -1,6 +1,6 @@
 import React from 'react'
 import {Heading, Text, StyledOcticon} from '@primer/components'
-import {RadioTower} from '@githubprimer/octicons-react'
+import {RadioTower} from '@primer/octicons-react'
 import ButtonPromo from './ButtonPromo'
 import LinkPromo from './LinkPromo'
 

--- a/src/MemberQuestions.js
+++ b/src/MemberQuestions.js
@@ -1,6 +1,6 @@
 import React from 'react'
 import {Text, Heading, Link, Box, StyledOcticon} from '@primer/components'
-import {MarkGithub} from '@githubprimer/octicons-react'
+import {MarkGithub} from '@primer/octicons-react'
 import ReactMarkdown from 'react-markdown'
 
 const MemberMarkdown = ({source, colorName}) => {

--- a/src/OcticonsPromo.js
+++ b/src/OcticonsPromo.js
@@ -1,6 +1,6 @@
 import React from 'react'
 import {Box, Heading, Text, Link, Flex, Relative, StyledOcticon} from '@primer/components'
-import {FileCode, Ruby, Paintcan} from '@githubprimer/octicons-react'
+import {FileCode, Ruby, Paintcan} from '@primer/octicons-react'
 import OcticonsImage from './svg/Octicons.svg'
 import LinkLight from './LinkLight'
 

--- a/src/OpenSource.js
+++ b/src/OpenSource.js
@@ -1,6 +1,6 @@
 import React from 'react'
 import {Box, BorderBox, Heading, Text, StyledOcticon} from '@primer/components'
-import {Octoface, MarkGithub} from '@githubprimer/octicons-react'
+import {Octoface, MarkGithub} from '@primer/octicons-react'
 import ButtonFillDark from './ButtonFillDark'
 import TwitterIcon from './TwitterIcon'
 import SpectrumIcon from './SpectrumIcon'

--- a/src/PrimerCSS.js
+++ b/src/PrimerCSS.js
@@ -1,6 +1,6 @@
 import React from 'react'
 import {Box, Heading, Text, Flex, StyledOcticon} from '@primer/components'
-import {Package} from '@githubprimer/octicons-react'
+import {Package} from '@primer/octicons-react'
 import CssImage from './svg/Css.svg'
 import IndexGrid from './IndexGrid'
 import ButtonFill from './ButtonFill'


### PR DESCRIPTION
Upgrading the use of `@githubprimer/octicons-react` to `@primer/octicons-react`. There wasn't any major api changes here, just the package rename.