### PR TITLE
Fix spacing issues w/new Primer Components

### DIFF
--- a/src/components/Layout.js
+++ b/src/components/Layout.js
@@ -1,10 +1,17 @@
 import React from 'react'
 import styled from 'styled-components'
 import {Helmet} from 'react-helmet'
-import {Box} from '@primer/components'
+import {Box, Heading} from '@primer/components'
 import {Header, ResponsiveJumpNav, JumpNav} from '@primer/blueprints'
 import siteMetadata from '../../meta'
 import '@primer/css/layout/index.scss'
+
+// FIXME: this works around known issues with Heading's default prop {m: 0}
+Object.assign(Heading.defaultProps, {
+  m: null,
+  mt: 0,
+  mb: 0
+})
 
 const Anchor = styled.div`
   display: block;

--- a/src/components/LinkDark.js
+++ b/src/components/LinkDark.js
@@ -1,12 +1,10 @@
 // Extends Link from primer/components to make color primitives available. Ideally I'd use defaultProps here but because we use !important on utilities the theme colors won't override. We could probably add a function to handle this.
 
 import {Link, themeGet} from '@primer/components'
-import {display} from 'styled-system'
 import styled from 'styled-components'
 
 const LinkDark = styled(Link)`
   color: ${themeGet('colors.black')} !important;
-  ${display};
   &:hover {
     color: ${themeGet('colors.gray.8')};
   }

--- a/src/components/LinkLight.js
+++ b/src/components/LinkLight.js
@@ -1,12 +1,10 @@
 // Extends Link from primer/components to make color primitives available. Ideally I'd use defaultProps here but because we use !important on utilities the theme colors won't override. We could probably add a function to handle this.
 
 import {Link, themeGet} from '@primer/components'
-import {display} from 'styled-system'
 import styled from 'styled-components'
 
 const LinkLight = styled(Link)`
   color: ${themeGet('colors.blue.3')} !important;
-  ${display};
 `
 
 LinkLight.defaultProps = {

--- a/src/components/OpenSource.js
+++ b/src/components/OpenSource.js
@@ -9,7 +9,7 @@ import LinkDark from './LinkDark'
 
 export default function OpenSource() {
   return (
-    <Box bg="blue.2" pt={12} mt={6}>
+    <Box bg="blue.2" pt={12} mt={8}>
       <IndexGrid alignItems="start">
         <IndexGrid.Item mb={[8, 8, 8, 0]}>
           <Heading color="black" mb={3} fontSize={7} fontWeight="bold">

--- a/src/components/OpenSource.js
+++ b/src/components/OpenSource.js
@@ -12,10 +12,10 @@ export default function OpenSource() {
     <Box bg="blue.2" pt={12} mt={6}>
       <IndexGrid alignItems="start">
         <IndexGrid.Item mb={[8, 8, 8, 0]}>
-          <Heading lineHeight="1.25" color="black" mb={3} fontSize={7} fontWeight="bold">
+          <Heading color="black" mb={3} fontSize={7} fontWeight="bold">
             Open source
           </Heading>
-          <Text as="p" color="black" mb={5} fontSize={4}>
+          <Text as="div" color="black" mb={5} fontSize={4}>
             Primer is open-sourced on GitHub. Contributions and feedback are welcome!
           </Text>
           <ButtonFillDark mr={2} href="https://github.com/primer">
@@ -24,7 +24,7 @@ export default function OpenSource() {
           </ButtonFillDark>
         </IndexGrid.Item>
         <IndexGrid.Item>
-          <Heading lineHeight="1.25" color="black" mb={3} fontSize={7} fontWeight="bold">
+          <Heading color="black" mb={3} fontSize={7} fontWeight="bold">
             Keep in touch
           </Heading>
           <LinkDark pt={1} fontSize={2} mb={3} display="block" href="https://twitter.com/githubprimer">

--- a/src/components/PrimerReact.js
+++ b/src/components/PrimerReact.js
@@ -1,13 +1,15 @@
 import React from 'react'
-import {Flex, Heading, Text, Link} from '@primer/components'
+import {Box, Flex, Heading, Text, Link} from '@primer/components'
 import LinkLight from './LinkLight'
 import {ReactComponent as ReactIcon} from '../svg/ReactIcon.svg'
 
 export default function PrimerReact() {
   return (
     <Flex alignItems="center" flexDirection="column" px={5} className="container-lg">
-      <ReactIcon width={72} />
-      <Heading fontSize={[4, 5]} mt={2} mb={2} color="blue.4">
+      <Box mb={2}>
+        <ReactIcon width={72} />
+      </Box>
+      <Heading fontSize={[4, 5]} mb={2} color="blue.4">
         Primer Components
         <Text fontSize={2} ml={1} style={{verticalAlign: 'text-top'}}>
           BETA

--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -11,7 +11,7 @@ import PrimerReact from '../components/PrimerReact'
 
 export default function Index(props) {
   return (
-    <Layout title="Home" {...props}>
+    <Layout {...props}>
       <Hero />
       <Divider my={[9, 12]} />
       <HiringPromo />

--- a/src/pages/news.js
+++ b/src/pages/news.js
@@ -7,7 +7,7 @@ import whatsNew from '../data/whats-new'
 
 export default function NewsIndex(props) {
   return (
-    <Layout {...props}>
+    <Layout title="News" {...props}>
       <Flex className="container-xl overflow-hidden" flexDirection="column" pt={8} px={5}>
         <Flex
           justifyContent="space-between"

--- a/src/pages/team.js
+++ b/src/pages/team.js
@@ -18,7 +18,7 @@ const getMemberContent = teamMembers => {
 
 export default function TeamIndex(props) {
   return (
-    <Layout {...props}>
+    <Layout title="Team" {...props}>
       <Flex className="container-xl overflow-hidden" flexDirection="column" pt={8} px={5}>
         <Flex
           justifyContent="space-between"


### PR DESCRIPTION
In #157 I upgraded from `@primer/components` v12.0.2 to v13.2.0, which introduced some layout wigginess. This PR isolates (with the exception of some Layout `title` prop tweaks) the fixes for them so they're easier to review.