### PR TITLE
Alias directly to primer.style

### DIFF
--- a/now.json
+++ b/now.json
@@ -1,7 +1,7 @@
 {
   "version": 2,
   "name": "primer-style",
-  "alias": "primer-style.now.sh",
+  "alias": "primer.style",
   "builds": [
     {
       "src": "package.json",


### PR DESCRIPTION
In #157 I switched our Now config over v2, but forgot to update the `alias` field in `now.json` from `primer-style.now.sh` (which used to be required for paths that weren't aliased to other hosts in Now v1) to `primer.style`. I've aliased the deployment manually in the meantime, but merging this should alias it again automatically.