### PR TITLE
Add Doctocat route

### DIFF
--- a/now.json
+++ b/now.json
@@ -15,6 +15,6 @@
     {"src": "/design(/.*)?", "dest": "https://primer-design.now.sh"},
     {"src": "/blueprints(/.*)?", "dest": "https://primer-blueprints.now.sh"},
     {"src": "/presentations(/.*)?", "dest": "https://primer-presentations.now.sh"},
-    {"src": "/doctocat(/.*)?", "dest": "https://doctocat.now.sh"}
+    {"src": "/doctocat(/.*)?", "dest": "https://doctocat-git-base-path.primer.now.sh"}
   ]
 }

--- a/now.json
+++ b/now.json
@@ -14,6 +14,7 @@
     {"src": "/css(/.*)?", "dest": "https://primer-css.now.sh"},
     {"src": "/design(/.*)?", "dest": "https://primer-design.now.sh"},
     {"src": "/blueprints(/.*)?", "dest": "https://primer-blueprints.now.sh"},
-    {"src": "/presentations(/.*)?", "dest": "https://primer-presentations.now.sh"}
+    {"src": "/presentations(/.*)?", "dest": "https://primer-presentations.now.sh"},
+    {"src": "/doctocat(/.*)?", "dest": "https://doctocat.now.sh"}
   ]
 }

--- a/now.json
+++ b/now.json
@@ -15,6 +15,6 @@
     {"src": "/design(/.*)?", "dest": "https://primer-design.now.sh"},
     {"src": "/blueprints(/.*)?", "dest": "https://primer-blueprints.now.sh"},
     {"src": "/presentations(/.*)?", "dest": "https://primer-presentations.now.sh"},
-    {"src": "/doctocat(/.*)?", "dest": "https://doctocat-git-base-path.primer.now.sh"}
+    {"src": "/doctocat(/.*)?", "dest": "https://doctocat.now.sh"}
   ]
 }


### PR DESCRIPTION
This pull request adds a Doctocat route to `now.json` so the Doctocat documentation can be accessed at `primer.style/doctocat`