### PR TITLE
Add /playroom route

### DIFF
--- a/now.json
+++ b/now.json
@@ -11,7 +11,7 @@
   ],
   "routes": [
     {"src": "/components(/.*)?", "dest": "https://primer-components.now.sh"},
-    {"src": "/playroom(/.*)?", "dest": "https://primer-components.now.sh/playroom"},
+    {"src": "/playroom(/.*)?", "dest": "https://primer-components.now.sh/playroom$1"},
     {"src": "/css(/.*)?", "dest": "https://primer-css.now.sh"},
     {"src": "/design(/.*)?", "dest": "https://primer-design.now.sh"},
     {"src": "/blueprints(/.*)?", "dest": "https://primer-blueprints.now.sh"},

--- a/now.json
+++ b/now.json
@@ -11,6 +11,7 @@
   ],
   "routes": [
     {"src": "/components(/.*)?", "dest": "https://primer-components.now.sh"},
+    {"src": "/playroom(/.*)?", "dest": "https://primer-components.now.sh"},
     {"src": "/css(/.*)?", "dest": "https://primer-css.now.sh"},
     {"src": "/design(/.*)?", "dest": "https://primer-design.now.sh"},
     {"src": "/blueprints(/.*)?", "dest": "https://primer-blueprints.now.sh"},

--- a/now.json
+++ b/now.json
@@ -11,7 +11,7 @@
   ],
   "routes": [
     {"src": "/components(/.*)?", "dest": "https://primer-components.now.sh"},
-    {"src": "/playroom(/.*)?", "dest": "https://primer-components.now.sh"},
+    {"src": "/playroom(/.*)?", "dest": "https://primer-components.now.sh/playroom"},
     {"src": "/css(/.*)?", "dest": "https://primer-css.now.sh"},
     {"src": "/design(/.*)?", "dest": "https://primer-design.now.sh"},
     {"src": "/blueprints(/.*)?", "dest": "https://primer-blueprints.now.sh"},


### PR DESCRIPTION
This PR sets up the `primer.style/playroom` URL. See https://github.com/primer/components/pull/690 for more details.