### PR TITLE
Add octicons route

### DIFF
--- a/now.json
+++ b/now.json
@@ -16,6 +16,7 @@
     {"src": "/blueprints(/.*)?", "dest": "https://primer-blueprints.now.sh"},
     {"src": "/presentations(/.*)?", "dest": "https://primer-presentations.now.sh"},
     {"src": "/doctocat(/.*)?", "dest": "https://doctocat.now.sh"},
-    {"src": "/octicons-v2(/.*)?", "dest": "https://octicons-v2.now.sh"}
+    {"src": "/octicons-v2(/.*)?", "dest": "https://octicons-v2.now.sh"},
+    {"src": "/octicons(/.*)?", "dest": "https://octicons.primer.now.sh"}
   ]
 }


### PR DESCRIPTION
This PR sets up a `https://primer.style/octicons` URL for the new Octicons site.