### PR TITLE
Update octicons-v2 alias

### DIFF
--- a/now.json
+++ b/now.json
@@ -16,7 +16,7 @@
     {"src": "/blueprints(/.*)?", "dest": "https://primer-blueprints.now.sh"},
     {"src": "/presentations(/.*)?", "dest": "https://primer-presentations.now.sh"},
     {"src": "/doctocat(/.*)?", "dest": "https://doctocat.now.sh"},
-    {"src": "/octicons-v2(/.*)?", "dest": "https://octicons-v2.now.sh"},
+    {"src": "/octicons-v2(/.*)?", "dest": "https://octicons-git-v2.primer.now.sh"},
     {"src": "/octicons(/.*)?", "dest": "https://octicons.primer.now.sh"}
   ]
 }


### PR DESCRIPTION
Make https://primer.style/octicons-v2 point to the most up-to-date v2 icons.