### PR TITLE
Redirect /octicons-v2 to /octicons

### DIFF
--- a/now.json
+++ b/now.json
@@ -18,7 +18,7 @@
     {"src": "/doctocat(/.*)?", "dest": "https://doctocat.now.sh"},
     {"src": "/octicons(/.*)?", "dest": "https://octicons.primer.now.sh"}
   ],
-  redirects: [
+  "redirects": [
     {"source": "/octicons-v2(/.*)?", "destination": "/octicons$1"},
   ]
 }

--- a/now.json
+++ b/now.json
@@ -19,6 +19,6 @@
     {"src": "/octicons(/.*)?", "dest": "https://octicons.primer.now.sh"}
   ],
   "redirects": [
-    {"source": "/octicons-v2(/.*)?", "destination": "/octicons$1"},
+    {"source": "/octicons-v2(/.*)?", "destination": "/octicons$1"}
   ]
 }

--- a/now.json
+++ b/now.json
@@ -17,6 +17,6 @@
     {"src": "/presentations(/.*)?", "dest": "https://primer-presentations.now.sh"},
     {"src": "/doctocat(/.*)?", "dest": "https://doctocat.now.sh"},
     {"src": "/octicons(/.*)?", "dest": "https://octicons.primer.now.sh"},
-    {"src": "/octicons-v2(/.*)?", "status": 301, "headers": {"Location": "/octicons"}}
+    {"src": "/octicons-v2(/.*)?", "status": 301, "headers": {"Location": "/octicons$1"}}
   ]
 }

--- a/now.json
+++ b/now.json
@@ -16,9 +16,7 @@
     {"src": "/blueprints(/.*)?", "dest": "https://primer-blueprints.now.sh"},
     {"src": "/presentations(/.*)?", "dest": "https://primer-presentations.now.sh"},
     {"src": "/doctocat(/.*)?", "dest": "https://doctocat.now.sh"},
-    {"src": "/octicons(/.*)?", "dest": "https://octicons.primer.now.sh"}
-  ],
-  "redirects": [
-    {"source": "/octicons-v2(/.*)?", "destination": "/octicons$1"}
+    {"src": "/octicons(/.*)?", "dest": "https://octicons.primer.now.sh"},
+    {"src": "/octicons-v2(/.*)?", "status": 301, "headers": {"Location": "/octicons"}}
   ]
 }

--- a/now.json
+++ b/now.json
@@ -16,7 +16,9 @@
     {"src": "/blueprints(/.*)?", "dest": "https://primer-blueprints.now.sh"},
     {"src": "/presentations(/.*)?", "dest": "https://primer-presentations.now.sh"},
     {"src": "/doctocat(/.*)?", "dest": "https://doctocat.now.sh"},
-    {"src": "/octicons-v2(/.*)?", "dest": "https://octicons-git-v2.primer.now.sh"},
     {"src": "/octicons(/.*)?", "dest": "https://octicons.primer.now.sh"}
+  ],
+  redirects: [
+    {"source": "/octicons-v2(/.*)?", "destination": "/octicons$1"},
   ]
 }


### PR DESCRIPTION
Redirects `primer.style/octicons-v2` links to `primer.style/octicons` because the `v2` branch of Octicons was merged into `master`.

Closes https://github.com/primer/primer.style/issues/198