### PR TITLE
Primer Components -> Primer React

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -3,7 +3,7 @@ Hi, and thanks for contributing to `primer.style`!
 
 
 ## Tools
-This site is built with [Gatsby] and [Primer Components].
+This site is built with [Gatsby] and [Primer React].
 
 
 ## Development
@@ -37,7 +37,7 @@ Now's [path alias] feature allows us to serve multiple apps under a single domai
 #### Path alias tips and tricks
 Because of the way that Now's path alias feature works, separate apps need to be configured to serve all of their URLs under the same path as they're aliased to on `primer.style`. In other words, an app aliased to `/alias/**` will need to serve all of its content from `/alias/` rather than `/`. For both Gatsby and Next.js, this means nesting all of your page content in `pages/<alias>/`.
 
-[primer components]: https://primer.style/components
+[Primer React]: https://primer.style/components
 [Now]: https://zeit.co/now
 [Now GitHub app]: https://github.com/apps/now
 [path alias]: https://zeit.co/docs/features/path-aliases

--- a/docs/contribute.md
+++ b/docs/contribute.md
@@ -19,7 +19,7 @@ These are the key repos you should watch if you’re interested in getting invol
 
 - [Design](https://github.com/primer/design)
 - [Primer CSS](https://github.com/primer/css)
-- [Primer Components (React)](https://github.com/primer/components)
+- [Primer React](https://github.com/primer/components)
 - [Octicons](https://github.com/primer/octicons)
 - [Doctocat](https://github.com/primer/doctocat)
 - [Design systems](https://github.com/github/design-systems) (internal to GitHub users)
@@ -32,7 +32,7 @@ If you spot something that doesn’t look right in our design, code or documenta
 
 - [Interface guidelines](https://github.com/primer/design) 
 - [Primer CSS](https://github.com/primer/css)
-- [Primer Components (React)](https://github.com/primer/components)
+- [Primer React](https://github.com/primer/components)
 - [Octicons](https://github.com/primer/octicons)
 - [Doctocat](https://github.com/primer/doctocat)
 - [Presentations](https://github.com/primer/presentations)

--- a/src/components/Article.js
+++ b/src/components/Article.js
@@ -13,7 +13,7 @@ export const iconForType = {
 const packageNames = {
   '@primer/css': 'Primer CSS',
   primer: 'Primer CSS',
-  '@primer/components': 'Primer Components',
+  '@primer/components': 'Primer React',
   '@primer/octicons': 'Octicons'
 }
 


### PR DESCRIPTION
This PR renames `Primer Components` to `Primer React`

To Do:
- When new doctocat version is released, update the version here before merging to get top nav changes