### PR TITLE
Add primer.style/primitives

### DIFF
--- a/now.json
+++ b/now.json
@@ -19,6 +19,6 @@
     {"src": "/cli(/.*)?", "dest": "https://cli.primer.vercel.app"},
     {"src": "/octicons(/.*)?", "dest": "https://octicons.primer.now.sh"},
     {"src": "/octicons-v2(/.*)?", "status": 301, "headers": {"Location": "/octicons$1"}},
-    {"src": "/primitives(/.*)?", "dest": "https://primitives-git-mkt-color-modes.primer.vercel.app"},
+    {"src": "/primitives(/.*)?", "dest": "https://primitives-git-mkt-color-modes.primer.vercel.app"}
   ]
 }

--- a/now.json
+++ b/now.json
@@ -18,6 +18,7 @@
     {"src": "/doctocat(/.*)?", "dest": "https://doctocat.now.sh"},
     {"src": "/cli(/.*)?", "dest": "https://cli.primer.vercel.app"},
     {"src": "/octicons(/.*)?", "dest": "https://octicons.primer.now.sh"},
-    {"src": "/octicons-v2(/.*)?", "status": 301, "headers": {"Location": "/octicons$1"}}
+    {"src": "/octicons-v2(/.*)?", "status": 301, "headers": {"Location": "/octicons$1"}},
+    {"src": "/primitives(/.*)?", "dest": "https://primitives-git-mkt-color-modes.primer.vercel.app"},
   ]
 }


### PR DESCRIPTION
This PR sets up the `primer.style/primitives` URL for the Primer Primitives docs site added in https://github.com/primer/primitives/pull/25