### PR TITLE
setup primer.style/view-components/stories URL

### DIFF
--- a/now.json
+++ b/now.json
@@ -21,6 +21,7 @@
     {"src": "/octicons-v2(/.*)?", "status": 301, "headers": {"Location": "/octicons$1"}},
     {"src": "/primitives(/.*)?", "dest": "https://primitives-git-mkt-color-modes.primer.vercel.app"},
     {"src": "/mobile(/.*)?", "dest": "https://mobile.primer.vercel.app"},
+    {"src": "/view-components/stories(/.*)?", "dest": "https://primer-view-components.herokuapp.com"},
     {"src": "/view-components(/.*)?", "dest": "https://view-components.vercel.app"},
     {"src": "/desktop(/.*)?", "dest": "https://desktop-nu.vercel.app"}
   ]


### PR DESCRIPTION
As part of the PrimerViewComponents documentation, we want to provide a way for our users to access a Storybook containing our components so they can interact with them.
We are currently hosting said Storybook in a Heroku application since it needs a Rails server to work, but we'd like to keep users in the `primer.style` brand. So, the proposed solution creates a redirect from `primer.style/view-components/stories` to the Heroku application. That way, users will never leave the `primer.style` brand and won't be exposed to a `.herokuapp`