### PR TITLE
Fix Octicons redirect

### DIFF
--- a/now.json
+++ b/now.json
@@ -17,7 +17,7 @@
     {"src": "/presentations(/.*)?", "dest": "https://primer-presentations.now.sh"},
     {"src": "/doctocat(/.*)?", "dest": "https://doctocat.now.sh"},
     {"src": "/cli(/.*)?", "dest": "https://cli.primer.vercel.app"},
-    {"src": "/octicons(/.*)?", "dest": "https://octicons.primer.now.sh"},
+    {"src": "/octicons(/.*)?", "dest": "https://octicons-primer.vercel.app/octicons"},
     {"src": "/octicons-v2(/.*)?", "status": 301, "headers": {"Location": "/octicons$1"}},
     {"src": "/primitives(/.*)?", "dest": "https://primitives-git-release-400-primer.vercel.app"},
     {"src": "/mobile(/.*)?", "dest": "https://mobile.primer.vercel.app"},


### PR DESCRIPTION
The Octicons URL started redirecting from `https://primer.style/octicons` to `https://octicons-vercel.app/octicons`. This PR fixes that.