### PR TITLE
Remove octoface from Primer.style homepage

### DIFF
--- a/src/components/Footer.js
+++ b/src/components/Footer.js
@@ -36,7 +36,7 @@ export default function OpenSource() {
             Chat with us in Spectrum
           </LinkDark>
           <LinkDark fontSize={2} mb={3} display="block" href="https://github.com/primer/css/issues/new/choose">
-            <StyledOcticon icon={Comment} size={20} verticalAlign="text-top" mr={2} />
+            <StyledOcticon icon={MarkGithub} size={20} verticalAlign="text-top" mr={2} />
             Share feedback on GitHub
           </LinkDark>
         </IndexGrid.Item>

--- a/src/components/Footer.js
+++ b/src/components/Footer.js
@@ -36,7 +36,7 @@ export default function OpenSource() {
             Chat with us in Spectrum
           </LinkDark>
           <LinkDark fontSize={2} mb={3} display="block" href="https://github.com/primer/css/issues/new/choose">
-            <StyledOcticon icon={Octoface} size={20} verticalAlign="text-top" mr={2} />
+            <StyledOcticon icon={Comment} size={20} verticalAlign="text-top" mr={2} />
             Share feedback on GitHub
           </LinkDark>
         </IndexGrid.Item>


### PR DESCRIPTION
This removes the octoface from the footer of Primer.style.

TY @gavinmn for the catch! ❤️ 