### PR TITLE
Add redirect for rails assets and routes

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -10,6 +10,7 @@
     {"source": "/octicons(/.*)?", "destination": "https://octicons-primer.vercel.app/octicons$1"},
     {"source": "/primitives(/.*)?", "destination": "https://primer-primitives.vercel.app/primitives$1"},
     {"source": "/mobile(/.*)?", "destination": "https://mobile.primer.vercel.app/mobile$1"},
+    {"source": "/rails(/.*)?", "destination": "https://primer-view-components.herokuapp.com/$1"},
     {"source": "/view-components/stories(/.*)?", "destination": "https://primer-view-components.herokuapp.com/view-components/stories$1"},
     {"source": "/view-components(/.*)?", "destination": "https://view-components.vercel.app/view-components$1"},
     {"source": "/desktop(/.*)?", "destination": "https://desktop-nu.vercel.app/desktop$1"},


### PR DESCRIPTION
Right now, we can't access PVC assets and testing controllers. With this redirect, we'll be able to load PVC javascript bundle in Storybook (which is failing now)

cc @inkblotty 