### PR TITLE
Add component status page

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
   "dependencies": {
     "@mdx-js/mdx": "^1.1.0",
     "@mdx-js/react": "^1.0.27",
+    "@primer/component-metadata": "^0.4.1",
     "@primer/components": "^17.1.1",
     "@primer/css": "^12.5.0",
     "@primer/gatsby-theme-doctocat": "1.8.1",

--- a/src/components/Layout.js
+++ b/src/components/Layout.js
@@ -1,7 +1,8 @@
-import {Box, Heading} from '@primer/components'
+import {Box, Heading, themeGet} from '@primer/components'
 import '@primer/css/layout/index.scss'
 import {Head, Header} from '@primer/gatsby-theme-doctocat'
 import React from 'react'
+import {createGlobalStyle} from 'styled-components'
 
 // FIXME: this works around known issues with Heading's default prop {m: 0}
 Object.assign(Heading.defaultProps, {
@@ -10,14 +11,20 @@ Object.assign(Heading.defaultProps, {
   mb: 0
 })
 
+const GlobalStyles = createGlobalStyle`
+  body {
+    color: ${themeGet('colors.blue.2')};
+    background-color: ${themeGet('colors.black')}; 
+  }
+`
+
 export default function Layout({pageContext, children}) {
   return (
     <>
+      <GlobalStyles />
       <Head title={pageContext.frontmatter.title} description={pageContext.frontmatter.description} />
       <Header isSearchEnabled={false} />
-      <Box bg="black" color="blue.2">
-        {children}
-      </Box>
+      <Box>{children}</Box>
     </>
   )
 }

--- a/src/components/Layout.js
+++ b/src/components/Layout.js
@@ -13,7 +13,6 @@ Object.assign(Heading.defaultProps, {
 
 const GlobalStyles = createGlobalStyle`
   body {
-    color: ${themeGet('colors.blue.2')};
     background-color: ${themeGet('colors.black')}; 
   }
 `
@@ -24,7 +23,7 @@ export default function Layout({pageContext, children}) {
       <GlobalStyles />
       <Head title={pageContext.frontmatter.title} description={pageContext.frontmatter.description} />
       <Header isSearchEnabled={false} />
-      <Box>{children}</Box>
+      <Box color="blue.2">{children}</Box>
     </>
   )
 }

--- a/src/pages/status.js
+++ b/src/pages/status.js
@@ -59,7 +59,11 @@ export default function StatusPage() {
   }, [])
 
   return (
-    <Layout pageContext={{frontmatter: {title: 'Status'}}}>
+    <Layout
+      pageContext={{
+        frontmatter: {title: 'Component status', description: 'Status of components in the Primer Design System'},
+      }}
+    >
       <Box className="container-xl" px={5} pb={8}>
         <Box pt={8} pb={6}>
           <Heading fontSize={[48, 56]} color="blue.4" lineHeight={1} mb={3}>

--- a/src/pages/status.js
+++ b/src/pages/status.js
@@ -1,0 +1,120 @@
+import componentMetadata from '@primer/component-metadata'
+import {Heading, Text, Box} from '@primer/components'
+import StatusLabel from '@primer/gatsby-theme-doctocat/src/components/status-label'
+import fetch from 'isomorphic-unfetch'
+import React from 'react'
+import Layout from '../components/Layout'
+
+export default function NewsPage() {
+  const [components, setComponents] = React.useState(null)
+
+  React.useEffect(() => {
+    getComponents().then((components) => setComponents(components))
+  }, [])
+
+  return (
+    <Layout pageContext={{frontmatter: {title: 'Status'}}}>
+      <div className="container-xl">
+        {components ? (
+          <table style={{width: '100%'}}>
+            <colgroup>
+              <col style={{width: '20%'}} />
+              <col style={{width: '20%'}} />
+              <col style={{width: '20%'}} />
+              <col style={{width: '40%'}} />
+            </colgroup>
+            <thead>
+              <tr>
+                <th align="left">Component</th>
+                {/* TODO: How would we add a Figma column? Where would that data come from ? */}
+                <th align="left">ViewComponent</th>
+                <th align="left">React</th>
+                <th align="left">Description</th>
+              </tr>
+            </thead>
+            <tbody>
+              {components.map((component) => (
+                <tr key={component.id}>
+                  <td>{component.displayName}</td>
+                  <td>
+                    {component.implementations.viewComponent ? (
+                      <a href={component.implementations.viewComponent.url}>
+                        <StatusLabel status={component.implementations.viewComponent.status} />
+                      </a>
+                    ) : (
+                      ''
+                    )}
+                  </td>
+                  <td>
+                    {component.implementations.react ? (
+                      <a href={component.implementations.react.url}>
+                        <StatusLabel status={component.implementations.react.status} />
+                      </a>
+                    ) : (
+                      ''
+                    )}
+                  </td>
+                  <td>{component.description}</td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        ) : null}
+      </div>
+    </Layout>
+  )
+}
+
+async function getComponents() {
+  // Get component status data
+  const viewComponents = await fetch(`https://primer.style/view-components/components.json`).then((res) => res.json())
+
+  const reactComponents = await fetch(`https://primer.style/react/components.json`).then((res) => res.json())
+
+  // TODO: handle errors
+
+  const implementations = {
+    react: {
+      url: 'https://primer.style/react',
+      data: reactComponents,
+    },
+    viewComponent: {
+      url: 'https://primer.style/view-components',
+      data: viewComponents,
+    },
+  }
+
+  const components = {}
+
+  for (const [implementation, {url, data}] of Object.entries(implementations)) {
+    for (const {id, path, status} of data) {
+      if (!(id in components)) {
+        components[id] = {
+          id,
+          displayName: idToDisplayName(id),
+          description: '',
+          implementations: {},
+        }
+      }
+
+      components[id].implementations[implementation] = {
+        status: status.charAt(0).toUpperCase() + status.slice(1), // Capitalize the first letter
+        url: `${url}${path}`,
+      }
+    }
+  }
+
+  for (const component of Object.values(componentMetadata.components)) {
+    if (component.id in components) {
+      components[component.id].displayName = component.displayName
+      components[component.id].description = component.description
+    }
+  }
+
+  return Object.values(components).sort((a, b) => a.id.localeCompare(b.id))
+}
+
+// Capitalize the first letter of the id and replace _ with spaces
+function idToDisplayName(str) {
+  return str.charAt(0).toUpperCase() + str.slice(1).replace(/_/g, ' ')
+}

--- a/src/pages/status.js
+++ b/src/pages/status.js
@@ -1,11 +1,57 @@
 import componentMetadata from '@primer/component-metadata'
-import {Heading, Text, Box} from '@primer/components'
+import {Box, Heading, Text, themeGet} from '@primer/components'
 import StatusLabel from '@primer/gatsby-theme-doctocat/src/components/status-label'
 import fetch from 'isomorphic-unfetch'
 import React from 'react'
+import styled from 'styled-components'
 import Layout from '../components/Layout'
+import LinkLight from '../components/LinkLight'
 
-export default function NewsPage() {
+// TODO: Make table header sticky
+const Table = styled.table`
+  display: block;
+  width: 100%;
+  overflow: auto;
+  position: relative;
+  border-collapse: collapse;
+
+  th {
+    font-family: ${themeGet('fonts.mono')};
+    font-weight: ${themeGet('fontWeights.normal')};
+    color: ${themeGet('colors.blue.3')};
+  }
+
+  th,
+  td {
+    padding: ${themeGet('space.2')} ${themeGet('space.3')};
+  }
+
+  th:first-child,
+  td:first-child {
+    padding-left: 0;
+  }
+
+  th:last-child,
+  td:last-child {
+    padding-right: 0;
+  }
+
+  td {
+    border-top: 1px solid ${themeGet('colors.gray.7')};
+    vertical-align: top;
+  }
+
+  th {
+    position: sticky;
+    top: 0;
+  }
+
+  img {
+    background-color: transparent;
+  }
+`
+
+export default function StatusPage() {
   const [components, setComponents] = React.useState(null)
 
   React.useEffect(() => {
@@ -14,29 +60,39 @@ export default function NewsPage() {
 
   return (
     <Layout pageContext={{frontmatter: {title: 'Status'}}}>
-      <div className="container-xl">
+      <Box className="container-xl" px={5} pb={8}>
+        <Box pt={8} pb={6}>
+          <Heading fontSize={[48, 56]} color="blue.4" lineHeight={1} mb={3}>
+            Component status
+          </Heading>
+          <Text as="p" fontSize={3} color="blue.2">
+            Status of components in the Primer Design System.
+            <br />
+            Check out the <LinkLight href="#">component lifecycle</LinkLight> for more information about each status.
+          </Text>
+        </Box>
         {components ? (
-          <table style={{width: '100%'}}>
+          <Table>
             <colgroup>
-              <col style={{width: '20%'}} />
-              <col style={{width: '20%'}} />
-              <col style={{width: '20%'}} />
-              <col style={{width: '40%'}} />
+              <col style={{width: '15%'}} />
+              <col style={{width: '15%'}} />
+              <col style={{width: '15%'}} />
+              <col style={{width: '55%'}} />
             </colgroup>
             <thead>
               <tr>
                 <th align="left">Component</th>
                 {/* TODO: How would we add a Figma column? Where would that data come from ? */}
-                <th align="left">ViewComponent</th>
-                <th align="left">React</th>
+                <th>ViewComponent</th>
+                <th>React</th>
                 <th align="left">Description</th>
               </tr>
             </thead>
             <tbody>
               {components.map((component) => (
                 <tr key={component.id}>
-                  <td>{component.displayName}</td>
-                  <td>
+                  <td style={{whiteSpace: 'nowrap'}}>{component.displayName}</td>
+                  <td align="center" style={{whiteSpace: 'nowrap'}}>
                     {component.implementations.viewComponent ? (
                       <a href={component.implementations.viewComponent.url}>
                         <StatusLabel status={component.implementations.viewComponent.status} />
@@ -45,22 +101,22 @@ export default function NewsPage() {
                       ''
                     )}
                   </td>
-                  <td>
+                  <td align="center" style={{whiteSpace: 'nowrap'}}>
                     {component.implementations.react ? (
                       <a href={component.implementations.react.url}>
                         <StatusLabel status={component.implementations.react.status} />
                       </a>
                     ) : (
-                      ''
+                      <Text color="gray.5">Not available</Text>
                     )}
                   </td>
-                  <td>{component.description}</td>
+                  <td style={{minWidth: 400}}>{component.description}</td>
                 </tr>
               ))}
             </tbody>
-          </table>
+          </Table>
         ) : null}
-      </div>
+      </Box>
     </Layout>
   )
 }

--- a/src/pages/status.js
+++ b/src/pages/status.js
@@ -55,7 +55,9 @@ export default function StatusPage() {
   const [components, setComponents] = React.useState(null)
 
   React.useEffect(() => {
-    getComponents().then((components) => setComponents(components))
+    getComponents()
+      .then((components) => setComponents(components))
+      .catch((error) => console.error(error))
   }, [])
 
   return (
@@ -130,8 +132,6 @@ async function getComponents() {
   const viewComponents = await fetch(`https://primer.style/view-components/components.json`).then((res) => res.json())
 
   const reactComponents = await fetch(`https://primer.style/react/components.json`).then((res) => res.json())
-
-  // TODO: handle errors
 
   const implementations = {
     react: {

--- a/yarn.lock
+++ b/yarn.lock
@@ -1732,6 +1732,11 @@
   resolved "https://registry.yarnpkg.com/@primer/component-metadata/-/component-metadata-0.4.0.tgz#44b7d7b1285bea41c2a88621fd17f2c777a4c5e9"
   integrity sha512-yppmDSSDrN2CHwjq3h+RWhfpjehFQAx21JcEipYyNTp0f/kC+iazFVNCKZE6DOavAxv003ti7QIrp+QkPT9tpg==
 
+"@primer/component-metadata@^0.4.1":
+  version "0.4.1"
+  resolved "https://registry.yarnpkg.com/@primer/component-metadata/-/component-metadata-0.4.1.tgz#86c4cda1bc6504cd5f9d523fac16c5e00556d881"
+  integrity sha512-iy5ZEeIRN6pFFG7px2ruuA726yVB/n4lsgM3msfdg9qJzfS9qE2JCqq2OuvQ+yXUTxb3JKROaDSH403kdpFR4Q==
+
 "@primer/components@^17.1.1":
   version "17.1.1"
   resolved "https://registry.yarnpkg.com/@primer/components/-/components-17.1.1.tgz#1d195785400116b87e9a78d138f7a24a01b207cc"


### PR DESCRIPTION
Co-authored-by: Charlotte Dann <pouretrebelle@github.com>

## Summary

Implements a cross-implementation component status page at `primer.style/status`.

👀  Preview:  https://primer-style-git-status-page-primer.vercel.app/status

![CleanShot 2021-12-15 at 12 18 55@2x](https://user-images.githubusercontent.com/4608155/146259048-d545bd25-99a6-4916-9d3f-012fcbfe627e.png)

A few implementation details:
* Component descriptions are pulled from [`@primer/component-metadata`](https://github.com/primer/component-metadata)
* ViewComponent statuses are pulled from https://primer.style/view-components/components.json
* React statuses are pulled from https://primer.style/react/components.json

## Next steps

- [ ] Add a link to `primer.style/status` in the Primer header. We may need to rethink the information architecture of the links in the header.
- [x] Add more React statuses by adding `componentId` frontmatter to all the markdown pages in the Primer React docs
- [ ] ~~(Nice to have) Make table header sticky so column headers stay visible as you scroll down the page~~ https://github.com/primer/primer.style/pull/282#discussion_r770588913

---

Part of https://github.com/github/primer/issues/114
