### PR TITLE
Replace origin url for primer.style/contribute

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -1,4 +1,5 @@
 {
+  "trailingSlash": true,
   "rewrites": [
     {"source": "/react(/.*)?", "destination": "https://primer-components.vercel.app/react$1"},
     {"source": "/css(/.*)?", "destination": "https://primer-css.vercel.app/css$1"},

--- a/vercel.json
+++ b/vercel.json
@@ -11,10 +11,13 @@
     {"source": "/primitives(/.*)?", "destination": "https://primer-primitives.vercel.app/primitives$1"},
     {"source": "/mobile(/.*)?", "destination": "https://mobile.primer.vercel.app/mobile$1"},
     {"source": "/rails(/.*)?", "destination": "https://primer-view-components.herokuapp.com/$1"},
-    {"source": "/view-components/stories(/.*)?", "destination": "https://view-components-storybook.eastus.cloudapp.azure.com/view-components/stories$1"},
+    {
+      "source": "/view-components/stories(/.*)?",
+      "destination": "https://view-components-storybook.eastus.cloudapp.azure.com/view-components/stories$1"
+    },
     {"source": "/view-components(/.*)?", "destination": "https://view-components.vercel.app/view-components$1"},
     {"source": "/desktop(/.*)?", "destination": "https://desktop-nu.vercel.app/desktop$1"},
-    {"source": "/contribute(/.*)?", "destination": "https://primer-contribute.vercel.app/contribute$1"}
+    {"source": "/contribute(/.*)?", "destination": "https://primer.github.io/contribute$1"}
   ],
   "redirects": [
     {"source": "/octicons-v2(/.*)?", "destination": "/octicons$1"},


### PR DESCRIPTION
Moves primer.style/contribute from Vercel to GitHub Pages.

Testing:

https://primer-style-git-rezrah-update-contribute-origin-primer.vercel.app/
https://primer-style-git-rezrah-update-contribute-origin-primer.vercel.app/contribute (w/o trailing slash - should redirect)
https://primer-style-git-rezrah-update-contribute-origin-primer.vercel.app/contribute/ (w/ trailing slash - as normal)