### PR TITLE
Switchover from Vercel to GitHub Pages

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -3,21 +3,21 @@
   "rewrites": [
     {"source": "/react(/.*)?", "destination": "https://primer-components.vercel.app/react$1"},
     {"source": "/css(/.*)?", "destination": "https://primer-css.vercel.app/css$1"},
-    {"source": "/design(/.*)?", "destination": "https://primer-design.vercel.app/design$1"},
+    {"source": "/design(/.*)?", "destination": "https://primer.github.io/design$1"},
     {"source": "/blueprints(/.*)?", "destination": "https://primer-blueprints.vercel.app"},
     {"source": "/presentations(/.*)?", "destination": "https://primer-presentations.vercel.app/presentations$1"},
     {"source": "/doctocat(/.*)?", "destination": "https://doctocat.vercel.app/doctocat$1"},
     {"source": "/cli(/.*)?", "destination": "https://cli.primer.vercel.app/cli$1"},
     {"source": "/octicons(/.*)?", "destination": "https://octicons-primer.vercel.app/octicons$1"},
     {"source": "/primitives(/.*)?", "destination": "https://primer-primitives.vercel.app/primitives$1"},
-    {"source": "/mobile(/.*)?", "destination": "https://mobile.primer.vercel.app/mobile$1"},
+    {"source": "/mobile(/.*)?", "destination": "https://primer.github.io/mobile$1"},
     {"source": "/rails(/.*)?", "destination": "https://primer-view-components.herokuapp.com/$1"},
     {
       "source": "/view-components/stories(/.*)?",
       "destination": "https://view-components-storybook.eastus.cloudapp.azure.com/view-components/stories$1"
     },
     {"source": "/view-components(/.*)?", "destination": "https://view-components.vercel.app/view-components$1"},
-    {"source": "/desktop(/.*)?", "destination": "https://desktop-nu.vercel.app/desktop$1"},
+    {"source": "/desktop(/.*)?", "destination": "https://primer.github.io/desktop$1"},
     {"source": "/contribute(/.*)?", "destination": "https://primer.github.io/contribute$1"}
   ],
   "redirects": [

--- a/vercel.json
+++ b/vercel.json
@@ -7,15 +7,15 @@
     {"source": "/presentations(/.*)?", "destination": "https://primer.github.io/presentations$1"},
     {"source": "/doctocat(/.*)?", "destination": "https://primer.github.io/doctocat$1"},
     {"source": "/cli(/.*)?", "destination": "https://primer.github.io/cli$1"},
-    {"source": "/octicons(/.*)?", "destination": "https://octicons-primer.vercel.app/octicons$1"},
-    {"source": "/primitives(/.*)?", "destination": "https://primer-primitives.vercel.app/primitives$1"},
+    {"source": "/octicons(/.*)?", "destination": "http://primer.github.io/octicons$1"},
+    {"source": "/primitives(/.*)?", "destination": "https://primer.github.io/primitives$1"},
     {"source": "/mobile(/.*)?", "destination": "https://primer.github.io/mobile$1"},
     {"source": "/react-brand(/.*)?", "destination": "https://primer.github.io/react-brand$1"},
     {
       "source": "/view-components/stories(/.*)?",
       "destination": "https://view-components-storybook.eastus.cloudapp.azure.com/view-components/stories$1"
     },
-    {"source": "/view-components(/.*)?", "destination": "https://view-components.vercel.app/view-components$1"},
+    {"source": "/view-components(/.*)?", "destination": "https://primer.github.io/view_components$1"},
     {"source": "/desktop(/.*)?", "destination": "https://primer.github.io/desktop$1"},
     {"source": "/contribute(/.*)?", "destination": "https://primer.github.io/contribute$1"}
   ],

--- a/vercel.json
+++ b/vercel.json
@@ -1,16 +1,16 @@
 {
   "trailingSlash": true,
   "rewrites": [
-    {"source": "/react(/.*)?", "destination": "https://primer-components.vercel.app/react$1"},
-    {"source": "/css(/.*)?", "destination": "https://primer-css.vercel.app/css$1"},
+    {"source": "/react(/.*)?", "destination": "https://primer.github.io/react$1"},
+    {"source": "/css(/.*)?", "destination": "https://primer.github.io/css$1"},
     {"source": "/design(/.*)?", "destination": "https://primer.github.io/design$1"},
     {"source": "/presentations(/.*)?", "destination": "https://primer.github.io/presentations$1"},
-    {"source": "/doctocat(/.*)?", "destination": "https://doctocat.vercel.app/doctocat$1"},
-    {"source": "/cli(/.*)?", "destination": "https://cli.primer.vercel.app/cli$1"},
+    {"source": "/doctocat(/.*)?", "destination": "https://primer.github.io/doctocat$1"},
+    {"source": "/cli(/.*)?", "destination": "https://primer.github.io/cli$1"},
     {"source": "/octicons(/.*)?", "destination": "https://octicons-primer.vercel.app/octicons$1"},
     {"source": "/primitives(/.*)?", "destination": "https://primer-primitives.vercel.app/primitives$1"},
     {"source": "/mobile(/.*)?", "destination": "https://primer.github.io/mobile$1"},
-    {"source": "/rails(/.*)?", "destination": "https://primer-view-components.herokuapp.com/$1"},
+    {"source": "/react-brand(/.*)?", "destination": "https://primer.github.io/react-brand$1"},
     {
       "source": "/view-components/stories(/.*)?",
       "destination": "https://view-components-storybook.eastus.cloudapp.azure.com/view-components/stories$1"

--- a/vercel.json
+++ b/vercel.json
@@ -4,7 +4,6 @@
     {"source": "/react(/.*)?", "destination": "https://primer-components.vercel.app/react$1"},
     {"source": "/css(/.*)?", "destination": "https://primer-css.vercel.app/css$1"},
     {"source": "/design(/.*)?", "destination": "https://primer.github.io/design$1"},
-    {"source": "/blueprints(/.*)?", "destination": "https://primer-blueprints.vercel.app"},
     {"source": "/presentations(/.*)?", "destination": "https://primer-presentations.vercel.app/presentations$1"},
     {"source": "/doctocat(/.*)?", "destination": "https://doctocat.vercel.app/doctocat$1"},
     {"source": "/cli(/.*)?", "destination": "https://cli.primer.vercel.app/cli$1"},

--- a/vercel.json
+++ b/vercel.json
@@ -4,7 +4,7 @@
     {"source": "/react(/.*)?", "destination": "https://primer-components.vercel.app/react$1"},
     {"source": "/css(/.*)?", "destination": "https://primer-css.vercel.app/css$1"},
     {"source": "/design(/.*)?", "destination": "https://primer.github.io/design$1"},
-    {"source": "/presentations(/.*)?", "destination": "https://primer-presentations.vercel.app/presentations$1"},
+    {"source": "/presentations(/.*)?", "destination": "https://primer.github.io/presentations$1"},
     {"source": "/doctocat(/.*)?", "destination": "https://doctocat.vercel.app/doctocat$1"},
     {"source": "/cli(/.*)?", "destination": "https://cli.primer.vercel.app/cli$1"},
     {"source": "/octicons(/.*)?", "destination": "https://octicons-primer.vercel.app/octicons$1"},


### PR DESCRIPTION
Points certain primer.style/* routes to new GitHub Pages origins via vercel-based url rewrites.

### Reviewers
During the migration from Vercel to GitHub Pages, certain pieces of content and functionality _may_ not have ported over correctly.

We would appreciate if maintainers of each repo can assist with a smoke test of their respective documentation sites, as they would be most familiar with how it functions at present.

1. Please open the URL for the docs you're familiar with below
2. Notify us via comment if you encounter any noticeable regressions to content, links or assets. 
3. If everything looks good, please give that item a check ✅  so we know it's good to go.

- [x] **CSS**: https://primer-style-git-rezrah-pages-switchover-primer.vercel.app/css
- [x] **Primitives**: https://primer-style-git-rezrah-pages-switchover-primer.vercel.app/primitives
- [x] **React**: https://primer-style-git-rezrah-pages-switchover-primer.vercel.app/react
- [x] **React Brand**: https://primer-style-git-rezrah-pages-switchover-primer.vercel.app/react-brand
- [x] **View Components**: https://primer-style-git-rezrah-pages-switchover-primer.vercel.app/view-components
- [x] **Design**: https://primer-style-git-rezrah-pages-switchover-primer.vercel.app/design
- [x] **Desktop**: https://primer-style-git-rezrah-pages-switchover-primer.vercel.app/desktop
- [x] **Mobile**: https://primer-style-git-rezrah-pages-switchover-primer.vercel.app/mobile
- [x] **CLI**: https://primer-style-git-rezrah-pages-switchover-primer.vercel.app/cli
- [x] **Contribute**: https://primer-style-git-rezrah-pages-switchover-primer.vercel.app/contribute
- [x] **Doctocat**: https://primer-style-git-rezrah-pages-switchover-primer.vercel.app/doctocat
