### PR TITLE
fix: update url to primer presentations

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -5,7 +5,7 @@
     {"source": "/css(/.*)?", "destination": "https://primer-css.vercel.app/css$1"},
     {"source": "/design(/.*)?", "destination": "https://primer-design.vercel.app/design$1"},
     {"source": "/blueprints(/.*)?", "destination": "https://primer-blueprints.vercel.app"},
-    {"source": "/presentations(/.*)?", "destination": "https://primer-presentations.vercel.app/presentations$1"},
+    {"source": "/presentations(/.*)?", "destination": "https://primer.github.io/presentations$1"},
     {"source": "/doctocat(/.*)?", "destination": "https://doctocat.vercel.app/doctocat$1"},
     {"source": "/cli(/.*)?", "destination": "https://cli.primer.vercel.app/cli$1"},
     {"source": "/octicons(/.*)?", "destination": "https://octicons-primer.vercel.app/octicons$1"},


### PR DESCRIPTION
Points Primer Presentations url at GitHub Pages instead of Vercel.

### Reviewers

Fixed url which no longer 404's: https://primer-style-n4zcovwkg-primer.vercel.app/presentations