### PR TITLE
Deploy primer.style to Azure

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -10,7 +10,7 @@ on:
 
 jobs:
   build:
-    runs-on: windows-latest
+    runs-on: ubuntu-latest
 
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -30,6 +30,8 @@ jobs:
         with:
           name: node-app
           path: ./public/
+      run: |
+        cp web.config ./public/
 
   deploy:
     runs-on: ubuntu-latest

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -30,8 +30,10 @@ jobs:
         with:
           name: node-app
           path: ./public/
-      run: |
-        cp web.config ./public/
+
+      - name: Copy rewrites to server root
+        run: |
+          cp web.config ./public/
 
   deploy:
     runs-on: ubuntu-latest

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -48,7 +48,7 @@ jobs:
         uses: azure/webapps-deploy@v2
         id: deploy-to-webapp
         with:
-          app-name: 'rezrah-test'
+          app-name: 'primerstyle'
           slot-name: 'production'
           publish-profile: ${{ secrets.AZURE_PUBLISH_PROFILE }}
           package: .

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -25,15 +25,15 @@ jobs:
           npm install
           npm run build --if-present
 
+      - name: Copy rewrites to server root
+        run: |
+          cp web.config public/
+
       - name: Upload artifact for deployment job
         uses: actions/upload-artifact@v2
         with:
           name: node-app
           path: ./public/
-
-      - name: Copy rewrites to server root
-        run: |
-          cp web.config ./public/
 
   deploy:
     runs-on: ubuntu-latest

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,52 @@
+name: Build and deploy production
+
+on:
+  push:
+    branches:
+      - main
+  workflow_dispatch:
+
+jobs:
+  build:
+    runs-on: windows-latest
+
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Set up Node.js version
+        uses: actions/setup-node@v1
+        with:
+          node-version: '16.x'
+
+      - name: npm install, build, and test
+        run: |
+          npm install
+          npm run build --if-present
+
+      - name: Upload artifact for deployment job
+        uses: actions/upload-artifact@v2
+        with:
+          name: node-app
+          path: ./public/
+
+  deploy:
+    runs-on: ubuntu-latest
+    needs: build
+    environment:
+      name: 'production'
+      url: ${{ steps.deploy-to-webapp.outputs.webapp-url }}
+
+    steps:
+      - name: Download artifact from build job
+        uses: actions/download-artifact@v2
+        with:
+          name: node-app
+
+      - name: 'Deploy to Azure Web App'
+        uses: azure/webapps-deploy@v2
+        id: deploy-to-webapp
+        with:
+          app-name: 'rezrah-test'
+          slot-name: 'production'
+          publish-profile: ${{ secrets.AZURE_PUBLISH_PROFILE }}
+          package: .

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -20,10 +20,10 @@ jobs:
         with:
           node-version: '14.x'
 
-      - name: npm install, build, and test
+      - name: install and build
         run: |
-          npm install
-          npm run build --if-present
+          yarn
+          yarn build
 
       - name: Copy rewrites to server root
         run: |
@@ -48,7 +48,7 @@ jobs:
         with:
           name: node-app
 
-      - name: 'Deploy to Azure Web App'
+      - name: Deploy to Azure Web App service
         uses: azure/webapps-deploy@v2
         id: deploy-to-webapp
         with:

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -18,7 +18,7 @@ jobs:
       - name: Set up Node.js version
         uses: actions/setup-node@v1
         with:
-          node-version: '16.x'
+          node-version: '14.x'
 
       - name: npm install, build, and test
         run: |

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -3,8 +3,7 @@ name: Build and deploy production
 on:
   push:
     branches:
-      - rezrah/azure-app-service-spike
-      # - main
+      - main
 
   workflow_dispatch:
 

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -3,7 +3,9 @@ name: Build and deploy production
 on:
   push:
     branches:
-      - main
+      - rezrah/azure-app-service-spike
+      # - main
+
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/deploy_preview.yml
+++ b/.github/workflows/deploy_preview.yml
@@ -1,0 +1,21 @@
+name: Deploy to preview environment
+
+on:
+  pull_request:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+jobs:
+  deploy:
+    name: Build and deploy
+    uses: primer/.github/.github/workflows/deploy_preview.yml@main
+    secrets:
+      gh_token: ${{ secrets.GITHUB_TOKEN }}
+    with:
+      node_version: 14
+      install: yarn
+      build: yarn build
+      output_dir: public

--- a/src/components/Footer.js
+++ b/src/components/Footer.js
@@ -39,7 +39,7 @@ export default function OpenSource() {
       <Box color="black" px={5} mx="auto" className="container-xl">
         <BorderBox mt={12} py={5} borderRadius={0} border={0} borderTop={2} borderStyle="solid" borderColor="black">
           <Text pr={1} as="span">
-            Created and maintained by GitHub&#8217;s
+            Created and maintained by GitHub&#8217;s (v1)
           </Text>
           <LinkDark fontWeight="bold" href="https://primer.style/about#team">
             Design Infrastructure team

--- a/src/components/Footer.js
+++ b/src/components/Footer.js
@@ -39,7 +39,7 @@ export default function OpenSource() {
       <Box color="black" px={5} mx="auto" className="container-xl">
         <BorderBox mt={12} py={5} borderRadius={0} border={0} borderTop={2} borderStyle="solid" borderColor="black">
           <Text pr={1} as="span">
-            Created and maintained by GitHub&#8217;s (v1)
+            Created and maintained by GitHub&#8217;s
           </Text>
           <LinkDark fontWeight="bold" href="https://primer.style/about#team">
             Design Infrastructure team

--- a/web.config
+++ b/web.config
@@ -1,10 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <configuration>
   <system.webServer>
-    <httpErrors errorMode="Custom" defaultResponseMode="ExecuteURL">
-        <remove statusCode="404" subStatusCode="-1" />
-        <error statusCode="404" path="/404" responseMode="ExecuteURL" />
-    </httpErrors>
+    <httpErrors existingResponse="PassThrough" />
     <rewrite>
       <rules>
         <!--BEGIN SSL-->

--- a/web.config
+++ b/web.config
@@ -31,7 +31,7 @@
         <rule name="React proxy" stopProcessing="true">
           <match url="^react/(.*)" ignoreCase="true" />
           <conditions>
-            <add input="{HTTP_HOST}" pattern="^(?:www.)?primer\.style$" />
+            <add input="{HTTP_HOST}" pattern="^(?:www.)?(.*)$" />
           </conditions>
           <action type="Rewrite" url="https://primer.github.io/react/{R:1}" />
           <serverVariables>
@@ -46,7 +46,7 @@
         <rule name="CSS proxy" stopProcessing="true">
           <match url="^css/(.*)" ignoreCase="true" />
           <conditions>
-            <add input="{HTTP_HOST}" pattern="^(?:www.)?primer\.style$" />
+            <add input="{HTTP_HOST}" pattern="^(?:www.)?(.*)$" />
           </conditions>
           <action type="Rewrite" url="https://primer.github.io/css/{R:1}" />
           <serverVariables>
@@ -61,7 +61,7 @@
         <rule name="ViewComponents Storybook proxy" stopProcessing="true">
           <match url="^view-components/stories/(.*)" ignoreCase="true" />
           <conditions>
-            <add input="{HTTP_HOST}" pattern="^(?:www.)?primer\.style$" />
+            <add input="{HTTP_HOST}" pattern="^(?:www.)?(.*)$" />
           </conditions>
           <action type="Rewrite" url="https://view-components-storybook.eastus.cloudapp.azure.com/view-components/stories/{R:1}" />
           <serverVariables>
@@ -74,7 +74,7 @@
         <rule name="ViewComponents proxy" stopProcessing="true">
           <match url="^view-components/(.*)" ignoreCase="true" />
           <conditions>
-            <add input="{HTTP_HOST}" pattern="^(?:www.)?primer\.style$" />
+            <add input="{HTTP_HOST}" pattern="^(?:www.)?(.*)$" />
           </conditions>
           <action type="Rewrite" url="https://primer.github.io/view_components/{R:1}" />
           <serverVariables>
@@ -89,7 +89,7 @@
         <rule name="Design proxy" stopProcessing="true">
           <match url="^design/(.*)" ignoreCase="true" />
           <conditions>
-            <add input="{HTTP_HOST}" pattern="^(?:www.)?primer\.style$" />
+            <add input="{HTTP_HOST}" pattern="^(?:www.)?(.*)$" />
           </conditions>
           <action type="Rewrite" url="https://primer.github.io/design/{R:1}" />
           <serverVariables>
@@ -104,7 +104,7 @@
         <rule name="Presentations proxy" stopProcessing="true">
           <match url="^presentations/(.*)" ignoreCase="true" />
           <conditions>
-            <add input="{HTTP_HOST}" pattern="^(?:www.)?primer\.style$" />
+            <add input="{HTTP_HOST}" pattern="^(?:www.)?(.*)$" />
           </conditions>
           <action type="Rewrite" url="https://primer.github.io/presentations/{R:1}" />
           <serverVariables>
@@ -119,7 +119,7 @@
         <rule name="Doctocat proxy" stopProcessing="true">
           <match url="^doctocat/(.*)" ignoreCase="true" />
           <conditions>
-            <add input="{HTTP_HOST}" pattern="^(?:www.)?primer\.style$" />
+            <add input="{HTTP_HOST}" pattern="^(?:www.)?(.*)$" />
           </conditions>
           <action type="Rewrite" url="https://primer.github.io/doctocat/{R:1}" />
           <serverVariables>
@@ -134,7 +134,7 @@
         <rule name="CLI proxy" stopProcessing="true">
           <match url="^cli/(.*)" ignoreCase="true" />
           <conditions>
-            <add input="{HTTP_HOST}" pattern="^(?:www.)?primer\.style$" />
+            <add input="{HTTP_HOST}" pattern="^(?:www.)?(.*)$" />
           </conditions>
           <action type="Rewrite" url="https://primer.github.io/cli/{R:1}" />
           <serverVariables>
@@ -149,7 +149,7 @@
         <rule name="Octicons proxy" stopProcessing="true">
           <match url="^octicons/(.*)" ignoreCase="true" />
           <conditions>
-            <add input="{HTTP_HOST}" pattern="^(?:www.)?primer\.style$" />
+            <add input="{HTTP_HOST}" pattern="^(?:www.)?(.*)$" />
           </conditions>
           <action type="Rewrite" url="https://primer.github.io/octicons/{R:1}" />
           <serverVariables>
@@ -164,7 +164,7 @@
         <rule name="Primitives proxy" stopProcessing="true">
           <match url="^primitives/(.*)" ignoreCase="true" />
           <conditions>
-            <add input="{HTTP_HOST}" pattern="^(?:www.)?primer\.style$" />
+            <add input="{HTTP_HOST}" pattern="^(?:www.)?(.*)$" />
           </conditions>
           <action type="Rewrite" url="https://primer.github.io/primitives/{R:1}" />
           <serverVariables>
@@ -179,7 +179,7 @@
         <rule name="Mobile proxy" stopProcessing="true">
           <match url="^mobile/(.*)" ignoreCase="true" />
           <conditions>
-            <add input="{HTTP_HOST}" pattern="^(?:www.)?primer\.style$" />
+            <add input="{HTTP_HOST}" pattern="^(?:www.)?(.*)$" />
           </conditions>
           <action type="Rewrite" url="https://primer.github.io/mobile/{R:1}" />
           <serverVariables>
@@ -194,7 +194,7 @@
         <rule name="React Brand proxy" stopProcessing="true">
           <match url="^react-brand/(.*)" ignoreCase="true" />
           <conditions>
-            <add input="{HTTP_HOST}" pattern="^(?:www.)?primer\.style$" />
+            <add input="{HTTP_HOST}" pattern="^(?:www.)?(.*)$" />
           </conditions>
           <action type="Rewrite" url="https://primer.github.io/react-brand/{R:1}" />
           <serverVariables>
@@ -209,7 +209,7 @@
         <rule name="Desktop proxy" stopProcessing="true">
           <match url="^desktop/(.*)" ignoreCase="true" />
           <conditions>
-            <add input="{HTTP_HOST}" pattern="^(?:www.)?primer\.style$" />
+            <add input="{HTTP_HOST}" pattern="^(?:www.)?(.*)$" />
           </conditions>
           <action type="Rewrite" url="https://primer.github.io/desktop/{R:1}" />
           <serverVariables>
@@ -224,7 +224,7 @@
         <rule name="Contribute proxy" stopProcessing="true">
           <match url="^contribute/(.*)" ignoreCase="true" />
           <conditions>
-            <add input="{HTTP_HOST}" pattern="^(?:www.)?primer\.style$" />
+            <add input="{HTTP_HOST}" pattern="^(?:www.)?(.*)$" />
           </conditions>
           <action type="Rewrite" url="https://primer.github.io/contribute/{R:1}" />
           <serverVariables>

--- a/web.config
+++ b/web.config
@@ -11,9 +11,10 @@
         <rule name="ForceSSL" stopProcessing="true">
           <match url="(.*)" />
           <conditions>
+            <add input="{HTTP_HOST}" pattern="^(www\.)(.+)$" /> 
             <add input="{HTTPS}" pattern="^OFF$" ignoreCase="true" />
           </conditions>
-          <action type="Redirect" url="https://{HTTP_HOST}/{R:1}" redirectType="Permanent" />
+          <action type="Redirect" url="https://{C:2}/{R:1}" redirectType="Permanent" />
         </rule>
         <!--END SSL-->
         <!--BEGIN Trailing slash enforcement-->

--- a/web.config
+++ b/web.config
@@ -11,7 +11,6 @@
         <rule name="ForceSSL" stopProcessing="true">
           <match url="(.*)" />
           <conditions>
-            <add input="{HTTP_HOST}" pattern="^(www\.)(.+)$" /> 
             <add input="{HTTPS}" pattern="^OFF$" ignoreCase="true" />
           </conditions>
           <action type="Redirect" url="https://{C:2}/{R:1}" redirectType="Permanent" />
@@ -32,7 +31,7 @@
         <rule name="React proxy" stopProcessing="true">
           <match url="^react/(.*)" ignoreCase="true" />
           <conditions>
-            <add input="{HTTP_HOST}" pattern="^primerstyle.azurewebsites\.net$" />
+            <add input="{HTTP_HOST}" pattern="^(?:www.)?primerstyle.azurewebsites\.net$" />
           </conditions>
           <action type="Rewrite" url="https://primer.github.io/react/{R:1}" />
           <serverVariables>
@@ -47,7 +46,7 @@
         <rule name="CSS proxy" stopProcessing="true">
           <match url="^css/(.*)" ignoreCase="true" />
           <conditions>
-            <add input="{HTTP_HOST}" pattern="^primerstyle.azurewebsites\.net$" />
+            <add input="{HTTP_HOST}" pattern="^(?:www.)?primerstyle.azurewebsites\.net$" />
           </conditions>
           <action type="Rewrite" url="https://primer.github.io/css/{R:1}" />
           <serverVariables>
@@ -62,7 +61,7 @@
         <rule name="ViewComponents Storybook proxy" stopProcessing="true">
           <match url="^view-components/stories/(.*)" ignoreCase="true" />
           <conditions>
-            <add input="{HTTP_HOST}" pattern="^primerstyle.azurewebsites\.net$" />
+            <add input="{HTTP_HOST}" pattern="^(?:www.)?primerstyle.azurewebsites\.net$" />
           </conditions>
           <action type="Rewrite" url="https://view-components-storybook.eastus.cloudapp.azure.com/view-components/stories/{R:1}" />
           <serverVariables>
@@ -75,7 +74,7 @@
         <rule name="ViewComponents proxy" stopProcessing="true">
           <match url="^view-components/(.*)" ignoreCase="true" />
           <conditions>
-            <add input="{HTTP_HOST}" pattern="^primerstyle.azurewebsites\.net$" />
+            <add input="{HTTP_HOST}" pattern="^(?:www.)?primerstyle.azurewebsites\.net$" />
           </conditions>
           <action type="Rewrite" url="https://primer.github.io/view_components/{R:1}" />
           <serverVariables>
@@ -90,7 +89,7 @@
         <rule name="Design proxy" stopProcessing="true">
           <match url="^design/(.*)" ignoreCase="true" />
           <conditions>
-            <add input="{HTTP_HOST}" pattern="^primerstyle.azurewebsites\.net$" />
+            <add input="{HTTP_HOST}" pattern="^(?:www.)?primerstyle.azurewebsites\.net$" />
           </conditions>
           <action type="Rewrite" url="https://primer.github.io/design/{R:1}" />
           <serverVariables>
@@ -105,7 +104,7 @@
         <rule name="Presentations proxy" stopProcessing="true">
           <match url="^presentations/(.*)" ignoreCase="true" />
           <conditions>
-            <add input="{HTTP_HOST}" pattern="^primerstyle.azurewebsites\.net$" />
+            <add input="{HTTP_HOST}" pattern="^(?:www.)?primerstyle.azurewebsites\.net$" />
           </conditions>
           <action type="Rewrite" url="https://primer.github.io/presentations/{R:1}" />
           <serverVariables>
@@ -120,7 +119,7 @@
         <rule name="Doctocat proxy" stopProcessing="true">
           <match url="^doctocat/(.*)" ignoreCase="true" />
           <conditions>
-            <add input="{HTTP_HOST}" pattern="^primerstyle.azurewebsites\.net$" />
+            <add input="{HTTP_HOST}" pattern="^(?:www.)?primerstyle.azurewebsites\.net$" />
           </conditions>
           <action type="Rewrite" url="https://primer.github.io/doctocat/{R:1}" />
           <serverVariables>
@@ -135,7 +134,7 @@
         <rule name="CLI proxy" stopProcessing="true">
           <match url="^cli/(.*)" ignoreCase="true" />
           <conditions>
-            <add input="{HTTP_HOST}" pattern="^primerstyle.azurewebsites\.net$" />
+            <add input="{HTTP_HOST}" pattern="^(?:www.)?primerstyle.azurewebsites\.net$" />
           </conditions>
           <action type="Rewrite" url="https://primer.github.io/cli/{R:1}" />
           <serverVariables>
@@ -150,7 +149,7 @@
         <rule name="Octicons proxy" stopProcessing="true">
           <match url="^octicons/(.*)" ignoreCase="true" />
           <conditions>
-            <add input="{HTTP_HOST}" pattern="^primerstyle.azurewebsites\.net$" />
+            <add input="{HTTP_HOST}" pattern="^(?:www.)?primerstyle.azurewebsites\.net$" />
           </conditions>
           <action type="Rewrite" url="https://primer.github.io/octicons/{R:1}" />
           <serverVariables>
@@ -165,7 +164,7 @@
         <rule name="Primitives proxy" stopProcessing="true">
           <match url="^primitives/(.*)" ignoreCase="true" />
           <conditions>
-            <add input="{HTTP_HOST}" pattern="^primerstyle.azurewebsites\.net$" />
+            <add input="{HTTP_HOST}" pattern="^(?:www.)?primerstyle.azurewebsites\.net$" />
           </conditions>
           <action type="Rewrite" url="https://primer.github.io/primitives/{R:1}" />
           <serverVariables>
@@ -180,7 +179,7 @@
         <rule name="Mobile proxy" stopProcessing="true">
           <match url="^mobile/(.*)" ignoreCase="true" />
           <conditions>
-            <add input="{HTTP_HOST}" pattern="^primerstyle.azurewebsites\.net$" />
+            <add input="{HTTP_HOST}" pattern="^(?:www.)?primerstyle.azurewebsites\.net$" />
           </conditions>
           <action type="Rewrite" url="https://primer.github.io/mobile/{R:1}" />
           <serverVariables>
@@ -195,7 +194,7 @@
         <rule name="React Brand proxy" stopProcessing="true">
           <match url="^react-brand/(.*)" ignoreCase="true" />
           <conditions>
-            <add input="{HTTP_HOST}" pattern="^primerstyle.azurewebsites\.net$" />
+            <add input="{HTTP_HOST}" pattern="^(?:www.)?primerstyle.azurewebsites\.net$" />
           </conditions>
           <action type="Rewrite" url="https://primer.github.io/react-brand/{R:1}" />
           <serverVariables>
@@ -210,7 +209,7 @@
         <rule name="Desktop proxy" stopProcessing="true">
           <match url="^desktop/(.*)" ignoreCase="true" />
           <conditions>
-            <add input="{HTTP_HOST}" pattern="^primerstyle.azurewebsites\.net$" />
+            <add input="{HTTP_HOST}" pattern="^(?:www.)?primerstyle.azurewebsites\.net$" />
           </conditions>
           <action type="Rewrite" url="https://primer.github.io/desktop/{R:1}" />
           <serverVariables>
@@ -225,7 +224,7 @@
         <rule name="Contribute proxy" stopProcessing="true">
           <match url="^contribute/(.*)" ignoreCase="true" />
           <conditions>
-            <add input="{HTTP_HOST}" pattern="^primerstyle.azurewebsites\.net$" />
+            <add input="{HTTP_HOST}" pattern="^(?:www.)?primerstyle.azurewebsites\.net$" />
           </conditions>
           <action type="Rewrite" url="https://primer.github.io/contribute/{R:1}" />
           <serverVariables>

--- a/web.config
+++ b/web.config
@@ -1,7 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <configuration>
   <system.webServer>
-    <httpErrors errorMode="Detailed" />
+    <httpErrors errorMode="Custom" defaultResponseMode="ExecuteURL">
+        <remove statusCode="404" subStatusCode="-1" />
+        <error statusCode="404" path="/404" responseMode="ExecuteURL" />
+    </httpErrors>
     <rewrite>
       <rules>
         <!--BEGIN SSL-->

--- a/web.config
+++ b/web.config
@@ -5,7 +5,6 @@
       <remove statusCode="404"/>
       <error statusCode="404" path="~/404/index.html"/>
     </httpErrors>
-  </system.webServer>
     <rewrite>
       <rules>
         <!--BEGIN SSL-->

--- a/web.config
+++ b/web.config
@@ -232,6 +232,10 @@
           </serverVariables>
         </rule>
         <!--END Primer Contribute-->
+        <rule name="Redirect /components" stopProcessing="true">
+          <match url="^components$" />
+          <action type="Redirect" redirectType="Permanent" url="/react" />
+        </rule>
       </rules>
       <outboundRules>
         <preConditions>

--- a/web.config
+++ b/web.config
@@ -4,6 +4,7 @@
     <httpErrors errorMode="Detailed" />
     <rewrite>
       <rules>
+        <!--BEGIN SSL-->
         <rule name="ForceSSL" stopProcessing="true">
           <match url="(.*)" />
           <conditions>
@@ -11,15 +12,19 @@
           </conditions>
           <action type="Redirect" url="https://{HTTP_HOST}/{R:1}" redirectType="Permanent" />
         </rule>
+        <!--END SSL-->
+        <!--BEGIN Trailing slash enforcement-->
         <rule name="Add trailing slash" stopProcessing="true">
-        <match url="(.*[^/])$" />
-        <conditions>
-          <add input="{REQUEST_FILENAME}" matchType="IsFile" negate="true" />
-          <add input="{REQUEST_FILENAME}" matchType="IsDirectory" negate="true" />
-          <add input="{REQUEST_FILENAME}" pattern="(.*?)\.[a-zA-Z]{1,4}$" negate="true" />
-        </conditions>
-        <action type="Redirect" redirectType="Permanent" url="{R:1}/" />
+          <match url="(.*[^/])$" />
+          <conditions>
+            <add input="{REQUEST_FILENAME}" matchType="IsFile" negate="true" />
+            <add input="{REQUEST_FILENAME}" matchType="IsDirectory" negate="true" />
+            <add input="{REQUEST_FILENAME}" pattern="(.*?)\.[a-zA-Z]{1,4}$" negate="true" />
+          </conditions>
+          <action type="Redirect" redirectType="Permanent" url="{R:1}/" />
         </rule> 
+        <!--END Trailing slash enforcement-->
+        <!--BEGIN Primer React Components-->
         <rule name="React proxy" stopProcessing="true">
           <match url="^react/(.*)" ignoreCase="true" />
           <conditions>
@@ -33,6 +38,8 @@
             <set name="HTTP_ACCEPT_ENCODING" value="" />
           </serverVariables>
         </rule>
+        <!--END Primer React Components-->
+        <!--BEGIN Primer CSS-->
         <rule name="CSS proxy" stopProcessing="true">
           <match url="^css/(.*)" ignoreCase="true" />
           <conditions>
@@ -46,6 +53,8 @@
             <set name="HTTP_ACCEPT_ENCODING" value="" />
           </serverVariables>
         </rule>
+        <!--END Primer CSS-->
+        <!--BEGIN Primer ViewComponents-->
         <rule name="ViewComponents Storybook proxy" stopProcessing="true">
           <match url="^view-components/stories/(.*)" ignoreCase="true" />
           <conditions>
@@ -72,10 +81,159 @@
             <set name="HTTP_ACCEPT_ENCODING" value="" />
           </serverVariables>
         </rule>
+        <!--END Primer ViewComponents-->
+        <!--BEGIN Primer Design-->
+        <rule name="Design proxy" stopProcessing="true">
+          <match url="^design/(.*)" ignoreCase="true" />
+          <conditions>
+            <add input="{HTTP_HOST}" pattern="^primerstyle.azurewebsites\.net$" />
+          </conditions>
+          <action type="Rewrite" url="https://primer.github.io/design/{R:1}" />
+          <serverVariables>
+            <set name="HTTP_X_UNPROXIED_URL" value="https://primer.github.io/design/{R:1}" />
+            <set name="HTTP_X_ORIGINAL_ACCEPT_ENCODING" value="{HTTP_ACCEPT_ENCODING}" />
+            <set name="HTTP_X_ORIGINAL_HOST" value="{HTTP_HOST}" />
+            <set name="HTTP_ACCEPT_ENCODING" value="" />
+          </serverVariables>
+        </rule>
+        <!--END Primer Design-->
+        <!--BEGIN Primer Presentations-->
+        <rule name="Presentations proxy" stopProcessing="true">
+          <match url="^presentations/(.*)" ignoreCase="true" />
+          <conditions>
+            <add input="{HTTP_HOST}" pattern="^primerstyle.azurewebsites\.net$" />
+          </conditions>
+          <action type="Rewrite" url="https://primer.github.io/presentations/{R:1}" />
+          <serverVariables>
+            <set name="HTTP_X_UNPROXIED_URL" value="https://primer.github.io/presentations/{R:1}" />
+            <set name="HTTP_X_ORIGINAL_ACCEPT_ENCODING" value="{HTTP_ACCEPT_ENCODING}" />
+            <set name="HTTP_X_ORIGINAL_HOST" value="{HTTP_HOST}" />
+            <set name="HTTP_ACCEPT_ENCODING" value="" />
+          </serverVariables>
+        </rule>
+        <!--END Primer Presentations-->
+        <!--BEGIN Primer Doctocat-->
+        <rule name="Doctocat proxy" stopProcessing="true">
+          <match url="^doctocat/(.*)" ignoreCase="true" />
+          <conditions>
+            <add input="{HTTP_HOST}" pattern="^primerstyle.azurewebsites\.net$" />
+          </conditions>
+          <action type="Rewrite" url="https://primer.github.io/doctocat/{R:1}" />
+          <serverVariables>
+            <set name="HTTP_X_UNPROXIED_URL" value="https://primer.github.io/doctocat/{R:1}" />
+            <set name="HTTP_X_ORIGINAL_ACCEPT_ENCODING" value="{HTTP_ACCEPT_ENCODING}" />
+            <set name="HTTP_X_ORIGINAL_HOST" value="{HTTP_HOST}" />
+            <set name="HTTP_ACCEPT_ENCODING" value="" />
+          </serverVariables>
+        </rule>
+        <!--END Primer Doctocat-->
+        <!--BEGIN Primer CLI-->
+        <rule name="CLI proxy" stopProcessing="true">
+          <match url="^cli/(.*)" ignoreCase="true" />
+          <conditions>
+            <add input="{HTTP_HOST}" pattern="^primerstyle.azurewebsites\.net$" />
+          </conditions>
+          <action type="Rewrite" url="https://primer.github.io/cli/{R:1}" />
+          <serverVariables>
+            <set name="HTTP_X_UNPROXIED_URL" value="https://primer.github.io/cli/{R:1}" />
+            <set name="HTTP_X_ORIGINAL_ACCEPT_ENCODING" value="{HTTP_ACCEPT_ENCODING}" />
+            <set name="HTTP_X_ORIGINAL_HOST" value="{HTTP_HOST}" />
+            <set name="HTTP_ACCEPT_ENCODING" value="" />
+          </serverVariables>
+        </rule>
+        <!--END Primer CLI-->
+        <!--BEGIN Primer Octicons-->
+        <rule name="Octicons proxy" stopProcessing="true">
+          <match url="^octicons/(.*)" ignoreCase="true" />
+          <conditions>
+            <add input="{HTTP_HOST}" pattern="^primerstyle.azurewebsites\.net$" />
+          </conditions>
+          <action type="Rewrite" url="https://primer.github.io/octicons/{R:1}" />
+          <serverVariables>
+            <set name="HTTP_X_UNPROXIED_URL" value="https://primer.github.io/octicons/{R:1}" />
+            <set name="HTTP_X_ORIGINAL_ACCEPT_ENCODING" value="{HTTP_ACCEPT_ENCODING}" />
+            <set name="HTTP_X_ORIGINAL_HOST" value="{HTTP_HOST}" />
+            <set name="HTTP_ACCEPT_ENCODING" value="" />
+          </serverVariables>
+        </rule>
+        <!--END Primer Octicons-->
+        <!--BEGIN Primer Primitives-->
+        <rule name="Primitives proxy" stopProcessing="true">
+          <match url="^primitives/(.*)" ignoreCase="true" />
+          <conditions>
+            <add input="{HTTP_HOST}" pattern="^primerstyle.azurewebsites\.net$" />
+          </conditions>
+          <action type="Rewrite" url="https://primer.github.io/primitives/{R:1}" />
+          <serverVariables>
+            <set name="HTTP_X_UNPROXIED_URL" value="https://primer.github.io/primitives/{R:1}" />
+            <set name="HTTP_X_ORIGINAL_ACCEPT_ENCODING" value="{HTTP_ACCEPT_ENCODING}" />
+            <set name="HTTP_X_ORIGINAL_HOST" value="{HTTP_HOST}" />
+            <set name="HTTP_ACCEPT_ENCODING" value="" />
+          </serverVariables>
+        </rule>
+        <!--END Primer Primitives-->
+        <!--BEGIN Primer Mobile-->
+        <rule name="Mobile proxy" stopProcessing="true">
+          <match url="^mobile/(.*)" ignoreCase="true" />
+          <conditions>
+            <add input="{HTTP_HOST}" pattern="^primerstyle.azurewebsites\.net$" />
+          </conditions>
+          <action type="Rewrite" url="https://primer.github.io/mobile/{R:1}" />
+          <serverVariables>
+            <set name="HTTP_X_UNPROXIED_URL" value="https://primer.github.io/mobile/{R:1}" />
+            <set name="HTTP_X_ORIGINAL_ACCEPT_ENCODING" value="{HTTP_ACCEPT_ENCODING}" />
+            <set name="HTTP_X_ORIGINAL_HOST" value="{HTTP_HOST}" />
+            <set name="HTTP_ACCEPT_ENCODING" value="" />
+          </serverVariables>
+        </rule>
+        <!--END Primer Mobile-->
+        <!--BEGIN Primer React Brand-->
+        <rule name="React Brand proxy" stopProcessing="true">
+          <match url="^react-brand/(.*)" ignoreCase="true" />
+          <conditions>
+            <add input="{HTTP_HOST}" pattern="^primerstyle.azurewebsites\.net$" />
+          </conditions>
+          <action type="Rewrite" url="https://primer.github.io/react-brand/{R:1}" />
+          <serverVariables>
+            <set name="HTTP_X_UNPROXIED_URL" value="https://primer.github.io/react-brand/{R:1}" />
+            <set name="HTTP_X_ORIGINAL_ACCEPT_ENCODING" value="{HTTP_ACCEPT_ENCODING}" />
+            <set name="HTTP_X_ORIGINAL_HOST" value="{HTTP_HOST}" />
+            <set name="HTTP_ACCEPT_ENCODING" value="" />
+          </serverVariables>
+        </rule>
+        <!--END Primer React Brand-->
+        <!--BEGIN Primer Desktop-->
+        <rule name="Desktop proxy" stopProcessing="true">
+          <match url="^desktop/(.*)" ignoreCase="true" />
+          <conditions>
+            <add input="{HTTP_HOST}" pattern="^primerstyle.azurewebsites\.net$" />
+          </conditions>
+          <action type="Rewrite" url="https://primer.github.io/desktop/{R:1}" />
+          <serverVariables>
+            <set name="HTTP_X_UNPROXIED_URL" value="https://primer.github.io/desktop/{R:1}" />
+            <set name="HTTP_X_ORIGINAL_ACCEPT_ENCODING" value="{HTTP_ACCEPT_ENCODING}" />
+            <set name="HTTP_X_ORIGINAL_HOST" value="{HTTP_HOST}" />
+            <set name="HTTP_ACCEPT_ENCODING" value="" />
+          </serverVariables>
+        </rule>
+        <!--END Primer Desktop-->
+        <!--BEGIN Primer Contribute-->
+        <rule name="Contribute proxy" stopProcessing="true">
+          <match url="^contribute/(.*)" ignoreCase="true" />
+          <conditions>
+            <add input="{HTTP_HOST}" pattern="^primerstyle.azurewebsites\.net$" />
+          </conditions>
+          <action type="Rewrite" url="https://primer.github.io/contribute/{R:1}" />
+          <serverVariables>
+            <set name="HTTP_X_UNPROXIED_URL" value="https://primer.github.io/contribute/{R:1}" />
+            <set name="HTTP_X_ORIGINAL_ACCEPT_ENCODING" value="{HTTP_ACCEPT_ENCODING}" />
+            <set name="HTTP_X_ORIGINAL_HOST" value="{HTTP_HOST}" />
+            <set name="HTTP_ACCEPT_ENCODING" value="" />
+          </serverVariables>
+        </rule>
+        <!--END Primer Contribute-->
       </rules>
       <outboundRules>
-        <!-- <rule name="ChangeReferencesToOriginalUrl" patternSyntax="ExactMatch" preCondition="CheckContentType"><match filterByTags="None" pattern="https://primer.github.io/react" /><action type="Rewrite" value="https://{HTTP_X_ORIGINAL_HOST}" /></rule>
-       -->
         <preConditions>
           <preCondition name="CheckContentType">
             <add input="{RESPONSE_CONTENT_TYPE}" pattern="^(text/html|text/plain|text/xml|application/rss\+xml)" />

--- a/web.config
+++ b/web.config
@@ -233,7 +233,7 @@
         </rule>
         <!--END Primer Contribute-->
         <rule name="Redirect /components" stopProcessing="true">
-          <match url="^components$" />
+          <match url="^components/(.*)" />
           <action type="Redirect" redirectType="Permanent" url="/react" />
         </rule>
       </rules>

--- a/web.config
+++ b/web.config
@@ -1,7 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <configuration>
   <system.webServer>
-    <httpErrors existingResponse="PassThrough" />
+    <httpErrors errorMode="Custom" defaultResponseMode="File">
+      <remove statusCode="404"/>
+      <error statusCode="404" path="~/404/index.html"/>
+    </httpErrors>
+  </system.webServer>
     <rewrite>
       <rules>
         <!--BEGIN SSL-->

--- a/web.config
+++ b/web.config
@@ -1,92 +1,87 @@
-<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="UTF-8"?>
 <configuration>
-	<system.webServer>
-		<httpErrors errorMode="Detailed" />
-		<rewrite>
-			<rules>
-				<rule name="ForceSSL" stopProcessing="true">
-					<match url="(.*)" />
-					<conditions>
-						<add input="{HTTPS}" pattern="^OFF$" ignoreCase="true" />
-					</conditions>
-					<action type="Redirect" url="https://{HTTP_HOST}/{R:1}" redirectType="Permanent" />
-				</rule>
+  <system.webServer>
+    <httpErrors errorMode="Detailed" />
+    <rewrite>
+      <rules>
+        <rule name="ForceSSL" stopProcessing="true">
+          <match url="(.*)" />
+          <conditions>
+            <add input="{HTTPS}" pattern="^OFF$" ignoreCase="true" />
+          </conditions>
+          <action type="Redirect" url="https://{HTTP_HOST}/{R:1}" redirectType="Permanent" />
+        </rule>
         <rule name="Add trailing slash" stopProcessing="true">
-          <match url="(.*[^/])$" />
-          <conditions>
-            <add input="{REQUEST_FILENAME}" matchType="IsFile" negate="true" />
-            <add input="{REQUEST_FILENAME}" matchType="IsDirectory" negate="true" />
-            <add input="{REQUEST_FILENAME}" pattern="(.*?)\.html$" negate="true" />
-            <add input="{REQUEST_FILENAME}" pattern="(.*?)\.css$" negate="true" />
-          </conditions>
-          <action type="Redirect" redirectType="Permanent" url="{R:1}/" />
-        </rule>
-				<rule name="React proxy" stopProcessing="true">
-					<match url="^react/(.*)" ignoreCase="true" />
+        <match url="(.*[^/])$" />
+        <conditions>
+          <add input="{REQUEST_FILENAME}" matchType="IsFile" negate="true" />
+          <add input="{REQUEST_FILENAME}" matchType="IsDirectory" negate="true" />
+          <add input="{REQUEST_FILENAME}" pattern="(.*?)\.[a-zA-Z]{1,4}$" negate="true" />
+        </conditions>
+        <action type="Redirect" redirectType="Permanent" url="{R:1}/" />
+        </rule> 
+        <rule name="React proxy" stopProcessing="true">
+          <match url="^react/(.*)" ignoreCase="true" />
           <conditions>
             <add input="{HTTP_HOST}" pattern="^primerstyle.azurewebsites\.net$" />
           </conditions>
-					<action type="Rewrite" url="https://primer.github.io/react/{R:1}" />
-					<serverVariables>
-						<set name="HTTP_X_UNPROXIED_URL" value="https://primer.github.io/react/{R:1}" /> 
-						<set name="HTTP_X_ORIGINAL_ACCEPT_ENCODING" value="{HTTP_ACCEPT_ENCODING}" /> 
-						<set name="HTTP_X_ORIGINAL_HOST" value="{HTTP_HOST}" />
-						<set name="HTTP_ACCEPT_ENCODING" value="" />
-					</serverVariables>
-				</rule>
+          <action type="Rewrite" url="https://primer.github.io/react/{R:1}" />
+          <serverVariables>
+            <set name="HTTP_X_UNPROXIED_URL" value="https://primer.github.io/react/{R:1}" />
+            <set name="HTTP_X_ORIGINAL_ACCEPT_ENCODING" value="{HTTP_ACCEPT_ENCODING}" />
+            <set name="HTTP_X_ORIGINAL_HOST" value="{HTTP_HOST}" />
+            <set name="HTTP_ACCEPT_ENCODING" value="" />
+          </serverVariables>
+        </rule>
         <rule name="CSS proxy" stopProcessing="true">
-					<match url="^css/(.*)" ignoreCase="true" />
+          <match url="^css/(.*)" ignoreCase="true" />
           <conditions>
             <add input="{HTTP_HOST}" pattern="^primerstyle.azurewebsites\.net$" />
           </conditions>
-					<action type="Rewrite" url="https://primer.github.io/css/{R:1}" />
-					<serverVariables>
-						<set name="HTTP_X_UNPROXIED_URL" value="https://primer.github.io/css/{R:1}" /> 
-						<set name="HTTP_X_ORIGINAL_ACCEPT_ENCODING" value="{HTTP_ACCEPT_ENCODING}" /> 
-						<set name="HTTP_X_ORIGINAL_HOST" value="{HTTP_HOST}" />
-						<set name="HTTP_ACCEPT_ENCODING" value="" />
-					</serverVariables>
-				</rule>
-        <rule name="ViewComponents Storybook proxy" stopProcessing="true">
-					<match url="^view-components/stories/(.*)" ignoreCase="true" />
-          <conditions>
-            <add input="{HTTP_HOST}" pattern="^primerstyle.azurewebsites\.net$" />
-          </conditions>
-					<action type="Rewrite" url="https://view-components-storybook.eastus.cloudapp.azure.com/view-components/stories/{R:1}" />
-					<serverVariables>
-						<set name="HTTP_X_UNPROXIED_URL" value="https://view-components-storybook.eastus.cloudapp.azure.com/view-components/stories/{R:1}" /> 
-						<set name="HTTP_X_ORIGINAL_ACCEPT_ENCODING" value="{HTTP_ACCEPT_ENCODING}" /> 
-						<set name="HTTP_X_ORIGINAL_HOST" value="{HTTP_HOST}" />
-						<set name="HTTP_ACCEPT_ENCODING" value="" />
-					</serverVariables>
-				</rule>
-        <rule name="ViewComponents proxy" stopProcessing="true">
-					<match url="^view-components/(.*)" ignoreCase="true" />
-          <conditions>
-            <add input="{HTTP_HOST}" pattern="^primerstyle.azurewebsites\.net$" />
-          </conditions>
-					<action type="Rewrite" url="https://primer.github.io/view_components/{R:1}" />
-					<serverVariables>
-						<set name="HTTP_X_UNPROXIED_URL" value="https://primer.github.io/view_components/{R:1}" /> 
-						<set name="HTTP_X_ORIGINAL_ACCEPT_ENCODING" value="{HTTP_ACCEPT_ENCODING}" /> 
-						<set name="HTTP_X_ORIGINAL_HOST" value="{HTTP_HOST}" />
-						<set name="HTTP_ACCEPT_ENCODING" value="" />
-					</serverVariables>
-				</rule>
-        
-			</rules>
-			<outboundRules>
-				<!-- <rule name="ChangeReferencesToOriginalUrl" patternSyntax="ExactMatch" preCondition="CheckContentType">
-          <match filterByTags="None" pattern="https://primer.github.io/react" />
-          <action type="Rewrite" value="https://{HTTP_X_ORIGINAL_HOST}" />
+          <action type="Rewrite" url="https://primer.github.io/css/{R:1}" />
+          <serverVariables>
+            <set name="HTTP_X_UNPROXIED_URL" value="https://primer.github.io/css/{R:1}" />
+            <set name="HTTP_X_ORIGINAL_ACCEPT_ENCODING" value="{HTTP_ACCEPT_ENCODING}" />
+            <set name="HTTP_X_ORIGINAL_HOST" value="{HTTP_HOST}" />
+            <set name="HTTP_ACCEPT_ENCODING" value="" />
+          </serverVariables>
         </rule>
+        <rule name="ViewComponents Storybook proxy" stopProcessing="true">
+          <match url="^view-components/stories/(.*)" ignoreCase="true" />
+          <conditions>
+            <add input="{HTTP_HOST}" pattern="^primerstyle.azurewebsites\.net$" />
+          </conditions>
+          <action type="Rewrite" url="https://view-components-storybook.eastus.cloudapp.azure.com/view-components/stories/{R:1}" />
+          <serverVariables>
+            <set name="HTTP_X_UNPROXIED_URL" value="https://view-components-storybook.eastus.cloudapp.azure.com/view-components/stories/{R:1}" />
+            <set name="HTTP_X_ORIGINAL_ACCEPT_ENCODING" value="{HTTP_ACCEPT_ENCODING}" />
+            <set name="HTTP_X_ORIGINAL_HOST" value="{HTTP_HOST}" />
+            <set name="HTTP_ACCEPT_ENCODING" value="" />
+          </serverVariables>
+        </rule>
+        <rule name="ViewComponents proxy" stopProcessing="true">
+          <match url="^view-components/(.*)" ignoreCase="true" />
+          <conditions>
+            <add input="{HTTP_HOST}" pattern="^primerstyle.azurewebsites\.net$" />
+          </conditions>
+          <action type="Rewrite" url="https://primer.github.io/view_components/{R:1}" />
+          <serverVariables>
+            <set name="HTTP_X_UNPROXIED_URL" value="https://primer.github.io/view_components/{R:1}" />
+            <set name="HTTP_X_ORIGINAL_ACCEPT_ENCODING" value="{HTTP_ACCEPT_ENCODING}" />
+            <set name="HTTP_X_ORIGINAL_HOST" value="{HTTP_HOST}" />
+            <set name="HTTP_ACCEPT_ENCODING" value="" />
+          </serverVariables>
+        </rule>
+      </rules>
+      <outboundRules>
+        <!-- <rule name="ChangeReferencesToOriginalUrl" patternSyntax="ExactMatch" preCondition="CheckContentType"><match filterByTags="None" pattern="https://primer.github.io/react" /><action type="Rewrite" value="https://{HTTP_X_ORIGINAL_HOST}" /></rule>
        -->
-				<preConditions>
-					<preCondition name="CheckContentType">
-						<add input="{RESPONSE_CONTENT_TYPE}" pattern="^(text/html|text/plain|text/xml|application/rss\+xml)" />
-					</preCondition>
-				</preConditions>
-			</outboundRules>
-		</rewrite>
-	</system.webServer>
+        <preConditions>
+          <preCondition name="CheckContentType">
+            <add input="{RESPONSE_CONTENT_TYPE}" pattern="^(text/html|text/plain|text/xml|application/rss\+xml)" />
+          </preCondition>
+        </preConditions>
+      </outboundRules>
+    </rewrite>
+  </system.webServer>
 </configuration>

--- a/web.config
+++ b/web.config
@@ -3,7 +3,7 @@
   <system.webServer>
     <httpErrors errorMode="Custom" defaultResponseMode="File">
       <remove statusCode="404"/>
-      <error statusCode="404" path="~/404/index.html"/>
+      <error statusCode="404" path="/404/index.html"/>
     </httpErrors>
     <rewrite>
       <rules>

--- a/web.config
+++ b/web.config
@@ -31,7 +31,7 @@
         <rule name="React proxy" stopProcessing="true">
           <match url="^react/(.*)" ignoreCase="true" />
           <conditions>
-            <add input="{HTTP_HOST}" pattern="^(?:www.)?primerstyle.azurewebsites\.net$" />
+            <add input="{HTTP_HOST}" pattern="^(?:www.)?primer\.style$" />
           </conditions>
           <action type="Rewrite" url="https://primer.github.io/react/{R:1}" />
           <serverVariables>
@@ -46,7 +46,7 @@
         <rule name="CSS proxy" stopProcessing="true">
           <match url="^css/(.*)" ignoreCase="true" />
           <conditions>
-            <add input="{HTTP_HOST}" pattern="^(?:www.)?primerstyle.azurewebsites\.net$" />
+            <add input="{HTTP_HOST}" pattern="^(?:www.)?primer\.style$" />
           </conditions>
           <action type="Rewrite" url="https://primer.github.io/css/{R:1}" />
           <serverVariables>
@@ -61,7 +61,7 @@
         <rule name="ViewComponents Storybook proxy" stopProcessing="true">
           <match url="^view-components/stories/(.*)" ignoreCase="true" />
           <conditions>
-            <add input="{HTTP_HOST}" pattern="^(?:www.)?primerstyle.azurewebsites\.net$" />
+            <add input="{HTTP_HOST}" pattern="^(?:www.)?primer\.style$" />
           </conditions>
           <action type="Rewrite" url="https://view-components-storybook.eastus.cloudapp.azure.com/view-components/stories/{R:1}" />
           <serverVariables>
@@ -74,7 +74,7 @@
         <rule name="ViewComponents proxy" stopProcessing="true">
           <match url="^view-components/(.*)" ignoreCase="true" />
           <conditions>
-            <add input="{HTTP_HOST}" pattern="^(?:www.)?primerstyle.azurewebsites\.net$" />
+            <add input="{HTTP_HOST}" pattern="^(?:www.)?primer\.style$" />
           </conditions>
           <action type="Rewrite" url="https://primer.github.io/view_components/{R:1}" />
           <serverVariables>
@@ -89,7 +89,7 @@
         <rule name="Design proxy" stopProcessing="true">
           <match url="^design/(.*)" ignoreCase="true" />
           <conditions>
-            <add input="{HTTP_HOST}" pattern="^(?:www.)?primerstyle.azurewebsites\.net$" />
+            <add input="{HTTP_HOST}" pattern="^(?:www.)?primer\.style$" />
           </conditions>
           <action type="Rewrite" url="https://primer.github.io/design/{R:1}" />
           <serverVariables>
@@ -104,7 +104,7 @@
         <rule name="Presentations proxy" stopProcessing="true">
           <match url="^presentations/(.*)" ignoreCase="true" />
           <conditions>
-            <add input="{HTTP_HOST}" pattern="^(?:www.)?primerstyle.azurewebsites\.net$" />
+            <add input="{HTTP_HOST}" pattern="^(?:www.)?primer\.style$" />
           </conditions>
           <action type="Rewrite" url="https://primer.github.io/presentations/{R:1}" />
           <serverVariables>
@@ -119,7 +119,7 @@
         <rule name="Doctocat proxy" stopProcessing="true">
           <match url="^doctocat/(.*)" ignoreCase="true" />
           <conditions>
-            <add input="{HTTP_HOST}" pattern="^(?:www.)?primerstyle.azurewebsites\.net$" />
+            <add input="{HTTP_HOST}" pattern="^(?:www.)?primer\.style$" />
           </conditions>
           <action type="Rewrite" url="https://primer.github.io/doctocat/{R:1}" />
           <serverVariables>
@@ -134,7 +134,7 @@
         <rule name="CLI proxy" stopProcessing="true">
           <match url="^cli/(.*)" ignoreCase="true" />
           <conditions>
-            <add input="{HTTP_HOST}" pattern="^(?:www.)?primerstyle.azurewebsites\.net$" />
+            <add input="{HTTP_HOST}" pattern="^(?:www.)?primer\.style$" />
           </conditions>
           <action type="Rewrite" url="https://primer.github.io/cli/{R:1}" />
           <serverVariables>
@@ -149,7 +149,7 @@
         <rule name="Octicons proxy" stopProcessing="true">
           <match url="^octicons/(.*)" ignoreCase="true" />
           <conditions>
-            <add input="{HTTP_HOST}" pattern="^(?:www.)?primerstyle.azurewebsites\.net$" />
+            <add input="{HTTP_HOST}" pattern="^(?:www.)?primer\.style$" />
           </conditions>
           <action type="Rewrite" url="https://primer.github.io/octicons/{R:1}" />
           <serverVariables>
@@ -164,7 +164,7 @@
         <rule name="Primitives proxy" stopProcessing="true">
           <match url="^primitives/(.*)" ignoreCase="true" />
           <conditions>
-            <add input="{HTTP_HOST}" pattern="^(?:www.)?primerstyle.azurewebsites\.net$" />
+            <add input="{HTTP_HOST}" pattern="^(?:www.)?primer\.style$" />
           </conditions>
           <action type="Rewrite" url="https://primer.github.io/primitives/{R:1}" />
           <serverVariables>
@@ -179,7 +179,7 @@
         <rule name="Mobile proxy" stopProcessing="true">
           <match url="^mobile/(.*)" ignoreCase="true" />
           <conditions>
-            <add input="{HTTP_HOST}" pattern="^(?:www.)?primerstyle.azurewebsites\.net$" />
+            <add input="{HTTP_HOST}" pattern="^(?:www.)?primer\.style$" />
           </conditions>
           <action type="Rewrite" url="https://primer.github.io/mobile/{R:1}" />
           <serverVariables>
@@ -194,7 +194,7 @@
         <rule name="React Brand proxy" stopProcessing="true">
           <match url="^react-brand/(.*)" ignoreCase="true" />
           <conditions>
-            <add input="{HTTP_HOST}" pattern="^(?:www.)?primerstyle.azurewebsites\.net$" />
+            <add input="{HTTP_HOST}" pattern="^(?:www.)?primer\.style$" />
           </conditions>
           <action type="Rewrite" url="https://primer.github.io/react-brand/{R:1}" />
           <serverVariables>
@@ -209,7 +209,7 @@
         <rule name="Desktop proxy" stopProcessing="true">
           <match url="^desktop/(.*)" ignoreCase="true" />
           <conditions>
-            <add input="{HTTP_HOST}" pattern="^(?:www.)?primerstyle.azurewebsites\.net$" />
+            <add input="{HTTP_HOST}" pattern="^(?:www.)?primer\.style$" />
           </conditions>
           <action type="Rewrite" url="https://primer.github.io/desktop/{R:1}" />
           <serverVariables>
@@ -224,7 +224,7 @@
         <rule name="Contribute proxy" stopProcessing="true">
           <match url="^contribute/(.*)" ignoreCase="true" />
           <conditions>
-            <add input="{HTTP_HOST}" pattern="^(?:www.)?primerstyle.azurewebsites\.net$" />
+            <add input="{HTTP_HOST}" pattern="^(?:www.)?primer\.style$" />
           </conditions>
           <action type="Rewrite" url="https://primer.github.io/contribute/{R:1}" />
           <serverVariables>

--- a/web.config
+++ b/web.config
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <configuration>
   <system.webServer>
-    <httpErrors errorMode="Custom" defaultResponseMode="File">
+    <httpErrors errorMode="Custom" existingResponse="Auto" defaultResponseMode="ExecuteURL" >
       <remove statusCode="404"/>
-      <error statusCode="404" path="/404/index.html"/>
+      <error statusCode="404" responseMode="ExecuteURL" path="/404/index.html" />
     </httpErrors>
     <rewrite>
       <rules>

--- a/web.config
+++ b/web.config
@@ -1,0 +1,92 @@
+<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+	<system.webServer>
+		<httpErrors errorMode="Detailed" />
+		<rewrite>
+			<rules>
+				<rule name="ForceSSL" stopProcessing="true">
+					<match url="(.*)" />
+					<conditions>
+						<add input="{HTTPS}" pattern="^OFF$" ignoreCase="true" />
+					</conditions>
+					<action type="Redirect" url="https://{HTTP_HOST}/{R:1}" redirectType="Permanent" />
+				</rule>
+        <rule name="Add trailing slash" stopProcessing="true">
+          <match url="(.*[^/])$" />
+          <conditions>
+            <add input="{REQUEST_FILENAME}" matchType="IsFile" negate="true" />
+            <add input="{REQUEST_FILENAME}" matchType="IsDirectory" negate="true" />
+            <add input="{REQUEST_FILENAME}" pattern="(.*?)\.html$" negate="true" />
+            <add input="{REQUEST_FILENAME}" pattern="(.*?)\.css$" negate="true" />
+          </conditions>
+          <action type="Redirect" redirectType="Permanent" url="{R:1}/" />
+        </rule>
+				<rule name="React proxy" stopProcessing="true">
+					<match url="^react/(.*)" ignoreCase="true" />
+          <conditions>
+            <add input="{HTTP_HOST}" pattern="^primerstyle.azurewebsites\.net$" />
+          </conditions>
+					<action type="Rewrite" url="https://primer.github.io/react/{R:1}" />
+					<serverVariables>
+						<set name="HTTP_X_UNPROXIED_URL" value="https://primer.github.io/react/{R:1}" /> 
+						<set name="HTTP_X_ORIGINAL_ACCEPT_ENCODING" value="{HTTP_ACCEPT_ENCODING}" /> 
+						<set name="HTTP_X_ORIGINAL_HOST" value="{HTTP_HOST}" />
+						<set name="HTTP_ACCEPT_ENCODING" value="" />
+					</serverVariables>
+				</rule>
+        <rule name="CSS proxy" stopProcessing="true">
+					<match url="^css/(.*)" ignoreCase="true" />
+          <conditions>
+            <add input="{HTTP_HOST}" pattern="^primerstyle.azurewebsites\.net$" />
+          </conditions>
+					<action type="Rewrite" url="https://primer.github.io/css/{R:1}" />
+					<serverVariables>
+						<set name="HTTP_X_UNPROXIED_URL" value="https://primer.github.io/css/{R:1}" /> 
+						<set name="HTTP_X_ORIGINAL_ACCEPT_ENCODING" value="{HTTP_ACCEPT_ENCODING}" /> 
+						<set name="HTTP_X_ORIGINAL_HOST" value="{HTTP_HOST}" />
+						<set name="HTTP_ACCEPT_ENCODING" value="" />
+					</serverVariables>
+				</rule>
+        <rule name="ViewComponents Storybook proxy" stopProcessing="true">
+					<match url="^view-components/stories/(.*)" ignoreCase="true" />
+          <conditions>
+            <add input="{HTTP_HOST}" pattern="^primerstyle.azurewebsites\.net$" />
+          </conditions>
+					<action type="Rewrite" url="https://view-components-storybook.eastus.cloudapp.azure.com/view-components/stories/{R:1}" />
+					<serverVariables>
+						<set name="HTTP_X_UNPROXIED_URL" value="https://view-components-storybook.eastus.cloudapp.azure.com/view-components/stories/{R:1}" /> 
+						<set name="HTTP_X_ORIGINAL_ACCEPT_ENCODING" value="{HTTP_ACCEPT_ENCODING}" /> 
+						<set name="HTTP_X_ORIGINAL_HOST" value="{HTTP_HOST}" />
+						<set name="HTTP_ACCEPT_ENCODING" value="" />
+					</serverVariables>
+				</rule>
+        <rule name="ViewComponents proxy" stopProcessing="true">
+					<match url="^view-components/(.*)" ignoreCase="true" />
+          <conditions>
+            <add input="{HTTP_HOST}" pattern="^primerstyle.azurewebsites\.net$" />
+          </conditions>
+					<action type="Rewrite" url="https://primer.github.io/view_components/{R:1}" />
+					<serverVariables>
+						<set name="HTTP_X_UNPROXIED_URL" value="https://primer.github.io/view_components/{R:1}" /> 
+						<set name="HTTP_X_ORIGINAL_ACCEPT_ENCODING" value="{HTTP_ACCEPT_ENCODING}" /> 
+						<set name="HTTP_X_ORIGINAL_HOST" value="{HTTP_HOST}" />
+						<set name="HTTP_ACCEPT_ENCODING" value="" />
+					</serverVariables>
+				</rule>
+        
+			</rules>
+			<outboundRules>
+				<!-- <rule name="ChangeReferencesToOriginalUrl" patternSyntax="ExactMatch" preCondition="CheckContentType">
+          <match filterByTags="None" pattern="https://primer.github.io/react" />
+          <action type="Rewrite" value="https://{HTTP_X_ORIGINAL_HOST}" />
+        </rule>
+       -->
+				<preConditions>
+					<preCondition name="CheckContentType">
+						<add input="{RESPONSE_CONTENT_TYPE}" pattern="^(text/html|text/plain|text/xml|application/rss\+xml)" />
+					</preCondition>
+				</preConditions>
+			</outboundRules>
+		</rewrite>
+	</system.webServer>
+</configuration>


### PR DESCRIPTION
Part of https://github.com/github/primer/issues/785

## What's changing?

- Deploys production site to Azure App Service on the Primer subscription
  - Previous Vercel rewrites have been converted to a `web.config` that is interpreted directly on the IIS Windows server on Azure
- Deploys previews for Pull Requests to GitHub Pages

## Reviewers
- Preview site: https://primerstyle.azurewebsites.net/
- CSS https://primerstyle.azurewebsites.net/css
- ViewComponents https://primerstyle.azurewebsites.net/view-components
- CLI https://primerstyle.azurewebsites.net/cli
- Desktop https://primerstyle.azurewebsites.net/desktop
- Design https://primerstyle.azurewebsites.net/design
- Mobile https://primerstyle.azurewebsites.net/mobile
- Doctocat https://primerstyle.azurewebsites.net/doctocat
- Octicons https://primerstyle.azurewebsites.net/octicons
- Presentations https://primerstyle.azurewebsites.net/presentations

## Post-merge Todo
- [x] DNS switchover
- [x] Regression testing
- [ ] Remove Vercel project for primer.style