### PR TITLE
Updating name of the teams who work on Primer

### DIFF
--- a/src/components/Team.js
+++ b/src/components/Team.js
@@ -23,7 +23,7 @@ export default function Team(props) {
             Meet the team
           </Heading>
           <Text as="p" fontSize={3} color="blue.2">
-            The GitHub Design Infrastructure team builds and maintains Primer — this includes our CSS framework, style guide
+            The GitHub Design Infrastructure and Design Engineering teams build and maintain Primer — this includes our CSS framework, style guide
             documentation, Octicons, numerous tools and libraries that support design and front-end, and our up-coming
             React.js component library.
           </Text>

--- a/src/components/Team.js
+++ b/src/components/Team.js
@@ -24,8 +24,7 @@ export default function Team(props) {
           </Heading>
           <Text as="p" fontSize={3} color="blue.2">
             The GitHub Design Infrastructure and Design Engineering teams build and maintain Primer — this includes our CSS framework, style guide
-            documentation, Octicons, numerous tools and libraries that support design and front-end, and our up-coming
-            React.js component library.
+            documentation, Octicons, numerous tools and libraries that support design and front-end, and component libraries.
           </Text>
 
           <Text fontSize={3} color="blue.2">


### PR DESCRIPTION
Team adjustments on the primer.style/about page:
- updating the name of the internal teams who work on Primer to reflect our new structure: https://github.com/github/design/discussions/27
- removing a reference to "our up-coming React.js component library" as it's no longer up-coming 😃 