### PR TITLE
Fix primer brand url rewrite

### DIFF
--- a/web.config
+++ b/web.config
@@ -198,21 +198,21 @@
           </serverVariables>
         </rule>
         <!--END Primer Mobile-->
-        <!--BEGIN Primer React Brand-->
-        <rule name="React Brand proxy" stopProcessing="true">
-          <match url="^react-brand/(.*)" ignoreCase="true" />
+        <!--BEGIN Primer Brand-->
+        <rule name="Primer Brand proxy" stopProcessing="true">
+          <match url="^brand/(.*)" ignoreCase="true" />
           <conditions>
             <add input="{HTTP_HOST}" pattern="^(?:www.)?(.*)$" />
           </conditions>
-          <action type="Rewrite" url="https://primer.github.io/react-brand/{R:1}" />
+          <action type="Rewrite" url="https://primer.github.io/brand/{R:1}" />
           <serverVariables>
-            <set name="HTTP_X_UNPROXIED_URL" value="https://primer.github.io/react-brand/{R:1}" />
+            <set name="HTTP_X_UNPROXIED_URL" value="https://primer.github.io/brand/{R:1}" />
             <set name="HTTP_X_ORIGINAL_ACCEPT_ENCODING" value="{HTTP_ACCEPT_ENCODING}" />
             <set name="HTTP_X_ORIGINAL_HOST" value="{HTTP_HOST}" />
             <set name="HTTP_ACCEPT_ENCODING" value="" />
           </serverVariables>
         </rule>
-        <!--END Primer React Brand-->
+        <!--END Primer Brand-->
         <!--BEGIN Primer Desktop-->
         <rule name="Desktop proxy" stopProcessing="true">
           <match url="^desktop/(.*)" ignoreCase="true" />


### PR DESCRIPTION
Primer React Brand has been renamed to Primer Brand, so we need to change the URL rewrite on primer.style.

```diff
- primer.style/react-brand
+ primer.style/brand
```