### PR TITLE
Add Accessibility column to the status table

### DIFF
--- a/src/components/Layout.js
+++ b/src/components/Layout.js
@@ -1,4 +1,4 @@
-import {Box, themeGet, ThemeProvider} from '@primer/react'
+import {Box, ThemeProvider} from '@primer/react'
 import {Head, Header} from '@primer/gatsby-theme-doctocat'
 import '@primer/css/layout/index.scss'
 import React from 'react'
@@ -8,7 +8,9 @@ export default function Layout({pageContext, children, colorMode}) {
     <ThemeProvider colorMode={colorMode || 'night'} nightScheme="dark_dimmed">
       <Head title={pageContext.frontmatter.title} description={pageContext.frontmatter.description} />
       <Header isSearchEnabled={false} />
-      <Box sx={{backgroundColor: 'canvas.default', color: 'fg.default'}}>{children}</Box>
+      <Box as={'main'} sx={{backgroundColor: 'canvas.default', color: 'fg.default'}}>
+        {children}
+      </Box>
     </ThemeProvider>
   )
 }

--- a/src/components/Team.js
+++ b/src/components/Team.js
@@ -20,10 +20,10 @@ export default function Team(props) {
         mx={-5}
       >
         <Box width={[1, 1, 1, 7 / 12]} pt={[0, 0, 0, 8]} pb={[8, 8, 8, 12]} px={5}>
-          <Heading sx={{color: 'accent.fg', fontSize: [48, 56], lineHeight: 1, mb: 3, mt: [4, 4, 4, 0]}}>
+          <Heading as={'h1'} sx={{color: 'accent.fg', fontSize: 7, mb: 2, mt: [4, 4, 4, 0]}}>
             Meet the team
           </Heading>
-          <Text as="p" sx={{fontSize: 3}}>
+          <Text as="p" sx={{m: 0, fontSize: 3}}>
             The GitHub Design Infrastructure and Design Engineering teams build and maintain Primer — this includes our
             CSS framework, style guide documentation, Octicons, numerous tools and libraries that support design and
             front-end, and component libraries.

--- a/src/pages/news.js
+++ b/src/pages/news.js
@@ -60,13 +60,14 @@ export default function NewsPage() {
           mx={-5}
         >
           <Box width={[1, 1, 1, 7 / 12]} pt={[0, 0, 0, 8]} pb={[6, 5, 5, 6]} px={5}>
-            <Heading sx={{fontSize: [48, 56], color: 'accent.fg', lineHeight: 1, mb: 3}}>What’s new</Heading>
-            <Text as="p" sx={{fontSize: 3}}>
+            <Heading as={'h1'} sx={{fontSize: 7, color: 'accent.fg', mb: 2}}>
+              What’s new
+            </Heading>
+            <Text as="p" sx={{fontSize: 3, m: 0}}>
               Keep up to date with the latest articles, podcasts, releases and talks from the GitHub Design Systems
               team.
             </Text>
           </Box>
-
           <Box position={'relative'} width={[11 / 12, 8 / 12, 8 / 12, 5 / 12]} mx="auto" mb={[4, 4, 4, 0]}>
             <Box px={5} style={{flexShrink: 0}}>
               <NewsImage width="100%" height={null} />

--- a/src/pages/status.js
+++ b/src/pages/status.js
@@ -13,10 +13,6 @@ const Table = styled.table`
   border-collapse: separate;
   border-spacing: 0;
 
-  th {
-    background-color: ${themeGet('colors.canvas.subtle')};
-  }
-
   a:hover {
     text-decoration: none;
   }
@@ -29,17 +25,29 @@ const Table = styled.table`
     border-width: 0;
     border-left-width: 1px;
     border-top-width: 1px;
+    font-weight: normal;
+    vertical-align: top;
   }
 
-  tr:first-child > th:first-child {
+  th {
+    background-color: ${themeGet('colors.canvas.subtle')};
+    font-weight: ${themeGet('fontWeights.bold')};
+    vertical-align: middle;
+  }
+
+  tbody th {
+    vertical-align: top;
+  }
+
+  thead tr:first-child > th:first-child {
     border-top-left-radius: 6px;
   }
 
-  tr:first-child > th:last-child {
+  thead tr:first-child > th:last-child {
     border-top-right-radius: 6px;
   }
 
-  tr:last-child > td:first-child {
+  tr:last-child > th:first-child {
     border-bottom-left-radius: 6px;
   }
 
@@ -52,7 +60,8 @@ const Table = styled.table`
     border-right-width: 1px;
   }
 
-  tr:last-child td {
+  tr:last-child td,
+  tbody tr:last-child th {
     border-bottom-width: 1px;
   }
 
@@ -120,7 +129,9 @@ export default function StatusPage() {
               {console.log('COMPTNNT', components)}
               {components.map((component) => (
                 <tr key={component.id}>
-                  <td style={{whiteSpace: 'nowrap'}}>{component.displayName}</td>
+                  <th align="left" scope="row" style={{whiteSpace: 'nowrap'}}>
+                    {component.displayName}
+                  </th>
                   <td align="center" style={{whiteSpace: 'nowrap'}}>
                     {component.implementations.viewComponent ? (
                       <Link href={component.implementations.viewComponent.url}>

--- a/src/pages/status.js
+++ b/src/pages/status.js
@@ -74,14 +74,14 @@ export default function StatusPage() {
       }}
     >
       <Box className="container-xl" px={5} pb={8}>
-        <Box pt={8} pb={6}>
-          <Heading sx={{fontSize: [48, 56], lineHeight: 1, mb: 3}}>Component status</Heading>
-          <Text as="p" sx={{fontSize: 3}}>
-            Status of components in the Primer Design System. <br />
-            Check out the <Link href="https://primer.style/contribute/component-lifecycle">
-              component lifecycle
-            </Link>{' '}
-            for more information about each status.
+        <Box width={[1, 1, 1, 7 / 12]} pt={8} pb={6}>
+          <Heading as="h1" sx={{fontSize: 7, mb: 2}}>
+            Component status
+          </Heading>
+          <Text as="p" sx={{m: 0, fontSize: 3}}>
+            Status of components in the Primer Design System. Check out the{' '}
+            <Link href="https://primer.style/contribute/component-lifecycle">component lifecycle</Link> for more
+            information about each status.
           </Text>
         </Box>
         {components ? (
@@ -117,40 +117,42 @@ export default function StatusPage() {
               {components.map((component) => (
                 <tr key={component.id}>
                   <td style={{whiteSpace: 'nowrap'}}>{component.displayName}</td>
-                  <td align="center" style={{whiteSpace: 'nowrap'}}>
+                  <td style={{whiteSpace: 'nowrap'}}>
                     {component.implementations.viewComponent ? (
                       <Link href={component.implementations.viewComponent.url}>
                         <StatusLabel status={component.implementations.viewComponent.status} />
                       </Link>
                     ) : (
-                      <Text sx={{color: 'fg.subtle'}}>-</Text>
+                      <Text sx={{fontSize: 1, color: 'fg.subtle'}}>Not available</Text>
                     )}
                   </td>
-                  <td align="center" style={{whiteSpace: 'nowrap'}}>
+                  <td style={{whiteSpace: 'nowrap'}}>
                     {component.implementations.viewComponent && component.implementations.viewComponent.accessible ? (
                       <Label variant="accent">Reviewed</Label>
                     ) : (
-                      <Text sx={{color: 'fg.subtle'}}>-</Text>
+                      <Text sx={{fontSize: 1, color: 'fg.subtle'}}>Not reviewed</Text>
                     )}
                   </td>
 
-                  <td align="center" style={{whiteSpace: 'nowrap'}}>
+                  <td style={{whiteSpace: 'nowrap'}}>
                     {component.implementations.react ? (
                       <Link href={component.implementations.react.url}>
                         <StatusLabel status={component.implementations.react.status} />
                       </Link>
                     ) : (
-                      <Text sx={{color: 'fg.subtle'}}>-</Text>
+                      <Text sx={{fontSize: 1, color: 'fg.subtle'}}>Not available</Text>
                     )}
                   </td>
-                  <td align="center" style={{whiteSpace: 'nowrap'}}>
+                  <td style={{whiteSpace: 'nowrap'}}>
                     {component.implementations.react && component.implementations.react.accessible ? (
-                      <Label variant="accent">Reviewed</Label>
+                      <Label variant="secondary">Reviewed</Label>
                     ) : (
-                      <Text sx={{color: 'fg.subtle'}}>-</Text>
+                      <Text sx={{fontSize: 1, color: 'fg.subtle'}}>Not reviewed</Text>
                     )}
                   </td>
-                  <td style={{minWidth: 400}}>{component.description}</td>
+                  <td style={{minWidth: 400}}>
+                    <Text sx={{fontSize: 1}}>{component.description}</Text>
+                  </td>
                 </tr>
               ))}
             </tbody>

--- a/src/pages/status.js
+++ b/src/pages/status.js
@@ -17,6 +17,10 @@ const Table = styled.table`
     background-color: ${themeGet('colors.canvas.subtle')};
   }
 
+  a:hover {
+    text-decoration: none;
+  }
+
   th,
   td {
     padding: ${themeGet('space.2')} ${themeGet('space.3')};
@@ -117,42 +121,40 @@ export default function StatusPage() {
               {components.map((component) => (
                 <tr key={component.id}>
                   <td style={{whiteSpace: 'nowrap'}}>{component.displayName}</td>
-                  <td style={{whiteSpace: 'nowrap'}}>
+                  <td align="center" style={{whiteSpace: 'nowrap'}}>
                     {component.implementations.viewComponent ? (
                       <Link href={component.implementations.viewComponent.url}>
                         <StatusLabel status={component.implementations.viewComponent.status} />
                       </Link>
                     ) : (
-                      <Text sx={{fontSize: 1, color: 'fg.subtle'}}>Not available</Text>
+                      <Text sx={{color: 'fg.subtle'}}>Not available</Text>
                     )}
                   </td>
-                  <td style={{whiteSpace: 'nowrap'}}>
+                  <td align="center" style={{whiteSpace: 'nowrap'}}>
                     {component.implementations.viewComponent && component.implementations.viewComponent.accessible ? (
-                      <Label variant="accent">Reviewed</Label>
+                      <Label variant="primary">Reviewed</Label>
                     ) : (
-                      <Text sx={{fontSize: 1, color: 'fg.subtle'}}>Not reviewed</Text>
+                      <Text sx={{color: 'fg.subtle'}}>Not reviewed</Text>
                     )}
                   </td>
 
-                  <td style={{whiteSpace: 'nowrap'}}>
+                  <td align="center" style={{whiteSpace: 'nowrap'}}>
                     {component.implementations.react ? (
                       <Link href={component.implementations.react.url}>
                         <StatusLabel status={component.implementations.react.status} />
                       </Link>
                     ) : (
-                      <Text sx={{fontSize: 1, color: 'fg.subtle'}}>Not available</Text>
+                      <Text sx={{color: 'fg.subtle'}}>Not available</Text>
                     )}
                   </td>
-                  <td style={{whiteSpace: 'nowrap'}}>
+                  <td align="center" style={{whiteSpace: 'nowrap'}}>
                     {component.implementations.react && component.implementations.react.accessible ? (
-                      <Label variant="secondary">Reviewed</Label>
+                      <Label variant="primary">Reviewed</Label>
                     ) : (
-                      <Text sx={{fontSize: 1, color: 'fg.subtle'}}>Not reviewed</Text>
+                      <Text sx={{color: 'fg.subtle'}}>Not reviewed</Text>
                     )}
                   </td>
-                  <td style={{minWidth: 400}}>
-                    <Text sx={{fontSize: 1}}>{component.description}</Text>
-                  </td>
+                  <td style={{minWidth: 400}}>{component.description}</td>
                 </tr>
               ))}
             </tbody>

--- a/src/pages/status.js
+++ b/src/pages/status.js
@@ -1,5 +1,5 @@
 import componentMetadata from '@primer/component-metadata'
-import {Box, Heading, Text, Link, themeGet} from '@primer/react'
+import {Box, Heading, Text, Link, Label, themeGet} from '@primer/react'
 import {StatusLabel} from '@primer/gatsby-theme-doctocat'
 import fetch from 'isomorphic-unfetch'
 import React from 'react'
@@ -10,43 +10,50 @@ import Layout from '../components/Layout'
 const Table = styled.table`
   display: block;
   width: 100%;
-  overflow: auto;
-  position: relative;
-  border-collapse: collapse;
+  border-collapse: separate;
+  border-spacing: 0;
 
   th {
-    font-family: ${themeGet('fonts.mono')};
-    font-weight: ${themeGet('fontWeights.normal')};
-    color: ${themeGet('colors.accent.fg')};
+    background-color: ${themeGet('colors.canvas.subtle')};
   }
 
   th,
   td {
     padding: ${themeGet('space.2')} ${themeGet('space.3')};
+    border-color: ${themeGet('colors.border.default')};
+    border-style: solid;
+    border-width: 0;
+    border-left-width: 1px;
+    border-top-width: 1px;
   }
 
-  th:first-child,
-  td:first-child {
-    padding-left: 0;
+  tr:first-child > th:first-child {
+    border-top-left-radius: 6px;
   }
 
-  th:last-child,
+  tr:first-child > th:last-child {
+    border-top-right-radius: 6px;
+  }
+
+  tr:last-child > td:first-child {
+    border-bottom-left-radius: 6px;
+  }
+
+  tr:last-child > td:last-child {
+    border-bottom-right-radius: 6px;
+  }
+
+  tr:first-child th:last-child,
   td:last-child {
-    padding-right: 0;
+    border-right-width: 1px;
+  }
+
+  tr:last-child td {
+    border-bottom-width: 1px;
   }
 
   td {
-    border-top: 1px solid ${themeGet('colors.border.default')};
     vertical-align: top;
-  }
-
-  th {
-    position: sticky;
-    top: 0;
-  }
-
-  img {
-    background-color: transparent;
   }
 `
 
@@ -61,13 +68,14 @@ export default function StatusPage() {
 
   return (
     <Layout
+      colorMode={'default'}
       pageContext={{
         frontmatter: {title: 'Component status', description: 'Status of components in the Primer Design System'},
       }}
     >
       <Box className="container-xl" px={5} pb={8}>
         <Box pt={8} pb={6}>
-          <Heading sx={{color: 'accent.fg', fontSize: [48, 56], lineHeight: 1, mb: 3}}>Component status</Heading>
+          <Heading sx={{fontSize: [48, 56], lineHeight: 1, mb: 3}}>Component status</Heading>
           <Text as="p" sx={{fontSize: 3}}>
             Status of components in the Primer Design System. <br />
             Check out the <Link href="https://primer.style/contribute/component-lifecycle">
@@ -78,22 +86,34 @@ export default function StatusPage() {
         </Box>
         {components ? (
           <Table>
-            <colgroup>
-              <col style={{width: '15%'}} />
-              <col style={{width: '15%'}} />
-              <col style={{width: '15%'}} />
-              <col style={{width: '55%'}} />
-            </colgroup>
+            <col />
+            <colgroup span="2" style={{textAlign: 'center'}}></colgroup>
+            <colgroup span="2" style={{textAlign: 'center'}}></colgroup>
+            <col />
             <thead>
               <tr>
-                <th align="left">Component</th>
-                {/* TODO: How would we add a Figma column? Where would that data come from ? */}
-                <th>ViewComponent</th>
-                <th>React</th>
-                <th align="left">Description</th>
+                <th align="left" rowspan="2" colspan="1">
+                  Component
+                </th>
+                <th rowspan="1" colspan="2">
+                  ViewComponent
+                </th>
+                <th rowspan="1" colspan="2">
+                  React
+                </th>
+                <th align="left" rowspan="2" colspan="1">
+                  Description
+                </th>
+              </tr>
+              <tr>
+                <th>Status</th>
+                <th>Accessibility</th>
+                <th>Status</th>
+                <th>Accessibility</th>
               </tr>
             </thead>
             <tbody>
+              {console.log('COMPTNNT', components)}
               {components.map((component) => (
                 <tr key={component.id}>
                   <td style={{whiteSpace: 'nowrap'}}>{component.displayName}</td>
@@ -103,16 +123,31 @@ export default function StatusPage() {
                         <StatusLabel status={component.implementations.viewComponent.status} />
                       </Link>
                     ) : (
-                      <Text sx={{color: 'fg.subtle'}}>Not available</Text>
+                      <Text sx={{color: 'fg.subtle'}}>-</Text>
                     )}
                   </td>
+                  <td align="center" style={{whiteSpace: 'nowrap'}}>
+                    {component.implementations.viewComponent && component.implementations.viewComponent.accessible ? (
+                      <Label variant="accent">Reviewed</Label>
+                    ) : (
+                      <Text sx={{color: 'fg.subtle'}}>-</Text>
+                    )}
+                  </td>
+
                   <td align="center" style={{whiteSpace: 'nowrap'}}>
                     {component.implementations.react ? (
                       <Link href={component.implementations.react.url}>
                         <StatusLabel status={component.implementations.react.status} />
                       </Link>
                     ) : (
-                      <Text sx={{color: 'fg.subtle'}}>Not available</Text>
+                      <Text sx={{color: 'fg.subtle'}}>-</Text>
+                    )}
+                  </td>
+                  <td align="center" style={{whiteSpace: 'nowrap'}}>
+                    {component.implementations.react && component.implementations.react.accessible ? (
+                      <Label variant="accent">Reviewed</Label>
+                    ) : (
+                      <Text sx={{color: 'fg.subtle'}}>-</Text>
                     )}
                   </td>
                   <td style={{minWidth: 400}}>{component.description}</td>
@@ -154,7 +189,7 @@ async function getComponents() {
   const components = {}
 
   for (const [implementation, {url, data}] of Object.entries(implementations)) {
-    for (const {id, path, status} of data) {
+    for (const {id, path, status, accessible} of data) {
       if (!(id in components)) {
         components[id] = {
           id,
@@ -167,6 +202,7 @@ async function getComponents() {
       components[id].implementations[implementation] = {
         status: status.charAt(0).toUpperCase() + status.slice(1), // Capitalize the first letter
         url: `${url}${path}`,
+        accessible: accessible || false,
       }
     }
   }

--- a/src/pages/status.js
+++ b/src/pages/status.js
@@ -189,7 +189,7 @@ async function getComponents() {
   const components = {}
 
   for (const [implementation, {url, data}] of Object.entries(implementations)) {
-    for (const {id, path, status, accessible} of data) {
+    for (const {id, path, status, a11yReviewed} of data) {
       if (!(id in components)) {
         components[id] = {
           id,
@@ -202,7 +202,7 @@ async function getComponents() {
       components[id].implementations[implementation] = {
         status: status.charAt(0).toUpperCase() + status.slice(1), // Capitalize the first letter
         url: `${url}${path}`,
-        accessible: accessible || false,
+        a11yReviewed: a11yReviewed || false,
       }
     }
   }


### PR DESCRIPTION
Add an accessibility column for each implementation in primer.style/status page. It will pull data from the React and View Components static files when the frontmatter variables are updated.

Tracking issue: https://github.com/github/primer/issues/1212

<img width="1820" alt="Screenshot 2022-09-12 at 17 24 44" src="https://user-images.githubusercontent.com/912236/189693436-0aa046f6-c99a-46ce-8029-99f918d37fb6.png">

