### PR TITLE
Use ActionMenu dropdown in status

### DIFF
--- a/src/components/StatusRows.js
+++ b/src/components/StatusRows.js
@@ -41,18 +41,18 @@ function AccessibilityLabel({a11yReviewed, size}) {
   }
 }
 
-export default function StatusRows({components, filter}) {
+export default function StatusRows({components, type}) {
   const labelSize = 'large'
 
-  if (filter) {
+  if (type) {
     components = components.filter(
       (component) =>
         (component.implementations.react &&
-          (component.implementations.react.status === filter ||
-            (component.implementations.react.a11yReviewed && filter === 'Accessibility'))) ||
+          (component.implementations.react.status === type ||
+            (component.implementations.react.a11yReviewed && type === 'Accessibility'))) ||
         (component.implementations.viewComponent &&
-          (component.implementations.viewComponent.status === filter ||
-            (component.implementations.viewComponent.a11yReviewed && filter === 'Accessibility')))
+          (component.implementations.viewComponent.status === type ||
+            (component.implementations.viewComponent.a11yReviewed && type === 'Accessibility')))
     )
   }
 

--- a/src/components/StatusRows.js
+++ b/src/components/StatusRows.js
@@ -49,10 +49,10 @@ export default function StatusRows({components, filter}) {
       (component) =>
         (component.implementations.react &&
           (component.implementations.react.status === filter ||
-            (component.implementations.react.a11yReviewed && filter === 'accessibility'))) ||
+            (component.implementations.react.a11yReviewed && filter === 'Accessibility'))) ||
         (component.implementations.viewComponent &&
           (component.implementations.viewComponent.status === filter ||
-            (component.implementations.viewComponent.a11yReviewed && filter === 'accessibility')))
+            (component.implementations.viewComponent.a11yReviewed && filter === 'Accessibility')))
     )
   }
 

--- a/src/pages/status.js
+++ b/src/pages/status.js
@@ -73,6 +73,17 @@ const Table = styled.table`
   }
 `
 
+const STATUS_COLORS = {
+  alpha: 'severe.fg',
+  beta: 'attention.fg',
+  stable: 'success.fg',
+  deprecated: 'danger.fg',
+}
+
+function getStatusColor(status) {
+  return STATUS_COLORS[status.toLowerCase()] || 'fg.muted'
+}
+
 const initialFieldTypes = [
   {filter: '', name: 'All components'},
   {filter: 'Accessibility', name: 'Reviewed for accessibility'},
@@ -89,6 +100,10 @@ export default function StatusPage() {
   }, [])
 
   const statusesList = components.reduce((statusesList, {implementations}) => {
+    if (implementations.viewComponent) {
+      statusesList.add(implementations.viewComponent.status)
+    }
+
     if (implementations.react) {
       statusesList.add(implementations.react.status)
     }
@@ -142,6 +157,17 @@ export default function StatusPage() {
                         selected={type.filter === selectedField.filter}
                         onSelect={() => setSelectedField(type)}
                       >
+                        <ActionList.LeadingVisual>
+                          <Box
+                            aria-hidden="true"
+                            sx={{
+                              height: '10px',
+                              width: '10px',
+                              backgroundColor: getStatusColor(type.filter),
+                              borderRadius: 99,
+                            }}
+                          />
+                        </ActionList.LeadingVisual>
                         {type.name}
                       </ActionList.Item>
                     ))}

--- a/src/pages/status.js
+++ b/src/pages/status.js
@@ -80,7 +80,7 @@ const initialFieldTypes = [
 
 export default function StatusPage() {
   const [components, setComponents] = React.useState([])
-  const [selectedIndex, setSelectedIndex] = React.useState(0)
+  const [selectedField, setSelectedField] = React.useState(initialFieldTypes[0])
 
   React.useEffect(() => {
     getComponents()
@@ -98,11 +98,8 @@ export default function StatusPage() {
 
   const statusFieldTypes = [...statusesList].map((status) => ({
     filter: status,
-    name: status + ' status',
+    name: status,
   }))
-
-  const fieldTypes = [...initialFieldTypes, ...statusFieldTypes]
-  const selectedType = fieldTypes[selectedIndex]
 
   return (
     <Layout
@@ -123,18 +120,32 @@ export default function StatusPage() {
               information about each status.
             </Text>
             <ActionMenu>
-              <ActionMenu.Button aria-label="Show components">Show: {selectedType.name}</ActionMenu.Button>
+              <ActionMenu.Button aria-label="Show components">Show: {selectedField.name}</ActionMenu.Button>
               <ActionMenu.Overlay width="medium">
                 <ActionList selectionVariant="single">
-                  {fieldTypes.map((type, index) => (
-                    <ActionList.Item
-                      key={index}
-                      selected={index === selectedIndex}
-                      onSelect={() => setSelectedIndex(index)}
-                    >
-                      {type.name}
-                    </ActionList.Item>
-                  ))}
+                  <ActionList.Group>
+                    {initialFieldTypes.map((type, index) => (
+                      <ActionList.Item
+                        key={index}
+                        selected={type.filter === selectedField.filter}
+                        onSelect={() => setSelectedField(type)}
+                      >
+                        {type.name}
+                      </ActionList.Item>
+                    ))}
+                  </ActionList.Group>
+                  <ActionList.Divider />
+                  <ActionList.Group title="Status">
+                    {statusFieldTypes.map((type, index) => (
+                      <ActionList.Item
+                        key={index}
+                        selected={type.filter === selectedField.filter}
+                        onSelect={() => setSelectedField(type)}
+                      >
+                        {type.name}
+                      </ActionList.Item>
+                    ))}
+                  </ActionList.Group>
                 </ActionList>
               </ActionMenu.Overlay>
             </ActionMenu>
@@ -168,7 +179,7 @@ export default function StatusPage() {
                 </tr>
               </thead>
               <tbody>
-                <StatusRows components={components} filter={selectedType.filter} />
+                <StatusRows components={components} filter={selectedField.filter} />
               </tbody>
             </Table>
           ) : null}

--- a/src/pages/status.js
+++ b/src/pages/status.js
@@ -85,8 +85,8 @@ function getStatusColor(status) {
 }
 
 const initialFieldTypes = [
-  {filter: '', name: 'All components'},
-  {filter: 'Accessibility', name: 'Reviewed for accessibility'},
+  {type: '', name: 'All components'},
+  {type: 'Accessibility', name: 'Reviewed for accessibility'},
 ]
 
 export default function StatusPage() {
@@ -112,7 +112,7 @@ export default function StatusPage() {
   }, new Set())
 
   const statusFieldTypes = [...statusesList].map((status) => ({
-    filter: status,
+    type: status,
     name: status,
   }))
 
@@ -139,36 +139,36 @@ export default function StatusPage() {
               <ActionMenu.Overlay width="medium">
                 <ActionList selectionVariant="single">
                   <ActionList.Group>
-                    {initialFieldTypes.map((type, index) => (
+                    {initialFieldTypes.map((field, index) => (
                       <ActionList.Item
                         key={index}
-                        selected={type.filter === selectedField.filter}
-                        onSelect={() => setSelectedField(type)}
+                        selected={field.type === selectedField.type}
+                        onSelect={() => setSelectedField(field)}
                       >
-                        {type.name}
+                        {field.name}
                       </ActionList.Item>
                     ))}
                   </ActionList.Group>
                   <ActionList.Divider />
                   <ActionList.Group title="Status">
-                    {statusFieldTypes.map((type, index) => (
+                    {statusFieldTypes.map((field, index) => (
                       <ActionList.Item
                         key={index}
-                        selected={type.filter === selectedField.filter}
-                        onSelect={() => setSelectedField(type)}
+                        selected={field.type === selectedField.type}
+                        onSelect={() => setSelectedField(field)}
                       >
                         <ActionList.LeadingVisual>
                           <Box
                             aria-hidden="true"
                             sx={{
-                              height: '10px',
-                              width: '10px',
-                              backgroundColor: getStatusColor(type.filter),
+                              height: '12px',
+                              width: '12px',
+                              backgroundColor: getStatusColor(field.type),
                               borderRadius: 99,
                             }}
                           />
                         </ActionList.LeadingVisual>
-                        {type.name}
+                        {field.name}
                       </ActionList.Item>
                     ))}
                   </ActionList.Group>
@@ -205,7 +205,7 @@ export default function StatusPage() {
                 </tr>
               </thead>
               <tbody>
-                <StatusRows components={components} filter={selectedField.filter} />
+                <StatusRows components={components} type={selectedField.type} />
               </tbody>
             </Table>
           ) : null}


### PR DESCRIPTION
- [x] Use the `ActionMenu` component to filter the primer.style/status components table
- [x] Group `Status` items in `ActionMenu`
- [x] Add `ActionList.LeadingVisual` to status group items.

👁️  Preview: https://primer-56883f1388-25991565.drafts.github.io/status/


<img width="678" alt="Screenshot 2022-10-24 at 11 15 30" src="https://user-images.githubusercontent.com/912236/197492223-35be3c9d-07dc-43cd-8dca-0bce16095f77.png">

