### PR TITLE
Bump component-metadata

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
   "dependencies": {
     "@mdx-js/mdx": "^1.1.0",
     "@mdx-js/react": "^1.0.27",
-    "@primer/component-metadata": "^0.4.1",
+    "@primer/component-metadata": "^0.5.0",
     "@primer/css": "^20.4.2",
     "@primer/gatsby-theme-doctocat": "^4.2.0",
     "@primer/octicons-react": "^17.7.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1833,10 +1833,15 @@
   resolved "https://registry.yarnpkg.com/@primer/behaviors/-/behaviors-1.1.3.tgz#4945f79c39f8b4495ec868b053264830f687c7bc"
   integrity sha512-WpCcjAkXG7Lv3ZbaCUgASWKHnCi/pmuSEiyTmHHb6f5xhwk1mliixNL5ZZHtDN6RCcT3VnXUsyek4GopG2lbZQ==
 
-"@primer/component-metadata@^0.4.0", "@primer/component-metadata@^0.4.1":
+"@primer/component-metadata@^0.4.0":
   version "0.4.1"
   resolved "https://registry.yarnpkg.com/@primer/component-metadata/-/component-metadata-0.4.1.tgz#86c4cda1bc6504cd5f9d523fac16c5e00556d881"
   integrity sha512-iy5ZEeIRN6pFFG7px2ruuA726yVB/n4lsgM3msfdg9qJzfS9qE2JCqq2OuvQ+yXUTxb3JKROaDSH403kdpFR4Q==
+
+"@primer/component-metadata@^0.5.0":
+  version "0.5.0"
+  resolved "https://registry.yarnpkg.com/@primer/component-metadata/-/component-metadata-0.5.0.tgz#89da29db69f585a17eec9d9cc1196481bb7d152c"
+  integrity sha512-8TcfWZ/6SAhNSQsjPXerKPefuKiiWJClcEiwPGbSNTBnPqXCEOGOb6mRaiD/SKb3ovWsXmdUwPvrSXyE9FjVYA==
 
 "@primer/css@^20.4.2":
   version "20.4.3"


### PR DESCRIPTION
Bump `component-metada` package that adds new component descriptions

Tracking issue: https://github.com/github/primer/issues/1213

Preview: https://primer-2caf7e69dc-25991565.drafts.github.io/status/