### PR TITLE
Correctly route traffic to the PVC Rails app

### DIFF
--- a/web.config
+++ b/web.config
@@ -33,7 +33,7 @@
             <add input="{URL}" negate="true" pattern="\.webmanifest$" />
           </conditions>
           <action type="Redirect" redirectType="Permanent" url="{R:1}/" />
-        </rule> 
+        </rule>
         <!--END Trailing slash enforcement-->
         <!--BEGIN Primer React Components-->
         <rule name="React proxy" stopProcessing="true">
@@ -100,6 +100,19 @@
           <action type="Rewrite" url="https://view-components-storybook.eastus.cloudapp.azure.com/view-components/lookbook/{R:1}" />
           <serverVariables>
             <set name="HTTP_X_UNPROXIED_URL" value="https://view-components-storybook.eastus.cloudapp.azure.com/view-components/lookbook/{R:1}" />
+            <set name="HTTP_X_ORIGINAL_ACCEPT_ENCODING" value="{HTTP_ACCEPT_ENCODING}" />
+            <set name="HTTP_X_ORIGINAL_HOST" value="{HTTP_HOST}" />
+            <set name="HTTP_ACCEPT_ENCODING" value="" />
+          </serverVariables>
+        </rule>
+        <rule name="ViewComponents Rails App proxy" stopProcessing="true">
+          <match url="^view-components/rails-app/(.*)" ignoreCase="true" />
+          <conditions>
+            <add input="{HTTP_HOST}" pattern="^(?:www.)?(.*)$" />
+          </conditions>
+          <action type="Rewrite" url="https://view-components-storybook.eastus.cloudapp.azure.com/view-components/rails-app/{R:1}" />
+          <serverVariables>
+            <set name="HTTP_X_UNPROXIED_URL" value="https://view-components-storybook.eastus.cloudapp.azure.com/view-components/rails-app/{R:1}" />
             <set name="HTTP_X_ORIGINAL_ACCEPT_ENCODING" value="{HTTP_ACCEPT_ENCODING}" />
             <set name="HTTP_X_ORIGINAL_HOST" value="{HTTP_HOST}" />
             <set name="HTTP_ACCEPT_ENCODING" value="" />


### PR DESCRIPTION
In combination with https://github.com/primer/view_components/pull/1693/commits/7bbb3bf3f28857696097cc095528e2ca40912d28, this change should allow all traffic to /view-components/rails-app to hit the PVC Rails app.