### PR TITLE
Add wildcard redirect for design/accessibility pages

### DIFF
--- a/web.config
+++ b/web.config
@@ -301,6 +301,11 @@
           <match url="^components/(.*)" />
           <action type="Redirect" redirectType="Permanent" url="/react" />
         </rule>
+        <!-- redirect all /design/accessibility to /design/guides/accessibility-->
+        <rule name="Redirect /design/accessibility" stopProcessing="true">
+          <match url="^design/accessibility/(.*)" />
+          <action type="Redirect" redirectType="Permanent" url="/design/guides/accessibility/{R:1}" />
+        </rule>
       </rules>
       <outboundRules>
         <preConditions>


### PR DESCRIPTION
Adds redirects for `primer.style/design/accessibility*` => `primer.style/design/guides/accessibility*`

Old pages are currently 404'ing

Part of https://github.com/github/primer/issues/1707

⚠️ Staging site doesn't seem operational right now. Will need to test this in production. 
