### PR TITLE
Fix design/accessibility redirects on primer.style

### DIFF
--- a/web.config
+++ b/web.config
@@ -35,6 +35,12 @@
           <action type="Redirect" redirectType="Temporary" url="{R:1}/" />
         </rule>
         <!--END Trailing slash enforcement-->
+        <!--BEGIN 301 redirects. Goes before URL rewrites -->
+        <rule name="Redirect /design/accessibility" stopProcessing="true">
+          <match url="(design)/(accessibility)(.*)" />
+          <action type="Redirect" redirectType="Permanent" url="/design/guides/accessibility{R:3}" />
+        </rule>
+        <!--END 301 redirects -->
         <!--BEGIN Primer React Components-->
         <rule name="React proxy" stopProcessing="true">
           <match url="^react/(.*)" ignoreCase="true" />
@@ -300,14 +306,6 @@
         <rule name="Redirect /components" stopProcessing="true">
           <match url="^components/(.*)" />
           <action type="Redirect" redirectType="Permanent" url="/react" />
-        </rule>
-        <rule name="Redirect /design/accessibility" stopProcessing="true">
-          <match url="(.*)" />
-          <conditions logicalGrouping="MatchAny" trackAllCaptures="false">
-            <add input="{HTTP_HOST}{REQUEST_URI}" pattern="primer.style/design/accessibility" />
-            <add input="{HTTP_HOST}{REQUEST_URI}" pattern="www.primer.style/design/accessibility" />
-          </conditions>
-          <action type="Redirect" url="http://primer.style/design/guides/accessibility" redirectType="Permanent"/>
         </rule>
       </rules>
       <outboundRules>


### PR DESCRIPTION
- Closes https://github.com/github/primer/issues/1707

2nd attempt. Fixes URL redirects by moving them above the rewrites, which were taking precedent. 

Now all urls that went to `primer.style/design/accessibility/*` go to `primer.style/design/guides/accessibility/*`

Fixed and tested on staging site:

https://primerstyle-staging.azurewebsites.net/design/accessibility
https://primerstyle-staging.azurewebsites.net/design/accessibility/tooltip-alternatives

☝️ These links would normally 404, but now will redirect correctly.