### PR TITLE
Add octicon redirects

### DIFF
--- a/web.config
+++ b/web.config
@@ -40,6 +40,34 @@
           <match url="(design)/(accessibility)(.*)" />
           <action type="Redirect" redirectType="Permanent" url="/design/guides/accessibility{R:3}" />
         </rule>
+        <rule name="Redirect /octicons/packages/ruby" stopProcessing="true">
+          <match url="octicons/packages/ruby" />
+          <action type="Redirect" redirectType="Permanent" url="https://github.com/primer/octicons/tree/main/lib/octicons_gem#readme" />
+        </rule>
+        <rule name="Redirect /octicons/packages/jekyll" stopProcessing="true">
+          <match url="octicons/packages/jekyll" />
+          <action type="Redirect" redirectType="Permanent" url="https://github.com/primer/octicons/tree/main/lib/octicons_jekyll#readme" />
+        </rule>
+        <rule name="Redirect /octicons/packages/javascript" stopProcessing="true">
+          <match url="octicons/packages/javascript" />
+          <action type="Redirect" redirectType="Permanent" url="https://github.com/primer/octicons/tree/main/lib/octicons_node#readme" />
+        </rule>
+        <rule name="Redirect /octicons/packages/react" stopProcessing="true">
+          <match url="octicons/packages/react" />
+          <action type="Redirect" redirectType="Permanent" url="https://github.com/primer/octicons/tree/main/lib/octicons_react#readme" />
+        </rule>
+        <rule name="Redirect /octicons/packages/styled-system" stopProcessing="true">
+          <match url="octicons/packages/styled-system" />
+          <action type="Redirect" redirectType="Permanent" url="https://github.com/primer/octicons/tree/main/lib/octicons_styled#readme" />
+        </rule>
+        <rule name="Redirect /octicons/guidelines/design" stopProcessing="true">
+          <match url="octicons/guidelines/design" />
+          <action type="Redirect" redirectType="Permanent" url="/design/foundations/icons/design-guidelines" />
+        </rule>
+        <rule name="Redirect /octicons/*" stopProcessing="true">
+          <match url="(octicons)(.*)" />
+          <action type="Redirect" redirectType="Permanent" url="/design/foundations/icons{R:2}" />
+       </rule>
         <!--END 301 redirects -->
         <!--BEGIN Primer React Components-->
         <rule name="React proxy" stopProcessing="true">
@@ -199,7 +227,7 @@
         </rule>
         <!--END Primer CLI-->
         <!--BEGIN Primer Octicons-->
-        <rule name="Octicons proxy" stopProcessing="true">
+        <!-- <rule name="Octicons proxy" stopProcessing="true">
           <match url="^octicons/(.*)" ignoreCase="true" />
           <conditions>
             <add input="{HTTP_HOST}" pattern="^(?:www.)?(.*)$" />
@@ -211,7 +239,7 @@
             <set name="HTTP_X_ORIGINAL_HOST" value="{HTTP_HOST}" />
             <set name="HTTP_ACCEPT_ENCODING" value="" />
           </serverVariables>
-        </rule>
+        </rule> -->
         <!--END Primer Octicons-->
         <!--BEGIN Primer Primitives-->
         <rule name="Primitives proxy" stopProcessing="true">


### PR DESCRIPTION
Closes https://github.com/primer/design/issues/389

Redirects are ready for testing in the staging branch:

In the following examples, you can assume that `https://primerstyle-staging.azurewebsites.net` is equivalent to `https://primer.style`. 

- https://primerstyle-staging.azurewebsites.net/octicons/guidelines/design/
- https://primerstyle-staging.azurewebsites.net/octicons/packages/ruby/
- https://primerstyle-staging.azurewebsites.net/octicons/packages/javascript/
- https://primerstyle-staging.azurewebsites.net/octicons/packages/jekyll/
- https://primerstyle-staging.azurewebsites.net/octicons/packages/styled-system/
- https://primerstyle-staging.azurewebsites.net/octicons/packages/react/
- https://primerstyle-staging.azurewebsites.net/octicons/accessibility-inset-16


☝ All of these should redirect to their new locations instead of 404. 
