### PR TITLE
Add primitive doc redirects

### DIFF
--- a/redirects.json
+++ b/redirects.json
@@ -144,8 +144,8 @@
     },
     {
       "name": "Redirect /primitives",
-      "match": "/primitives",
-      "destination": "https://primer.style/primitives/storybook/"
+      "match": "^primitives/?$",
+      "destination": "/primitives/storybook/"
     }
   ]
 }

--- a/redirects.json
+++ b/redirects.json
@@ -126,6 +126,26 @@
       "name": "CSS reverse-proxy",
       "match": "^css/(.*)",
       "destination": "https://primer.github.io/css/{R:1}"
+    },
+    {
+      "name": "Redirect /primitives/colors",
+      "match": "/primitives/colors",
+      "destination": "https://primer.style/design/foundations/color"
+    },
+    {
+      "name": "Redirect /primitives/spacing",
+      "match": "/primitives/spacing",
+      "destination": "https://primer.style/primitives/storybook/?path=/story/size-base--base"
+    },
+    {
+      "name": "Redirect /primitives/typography",
+      "match": "/primitives/typography",
+      "destination": "https://primer.style/primitives/storybook/?path=/story/typography-base--base"
+    },
+    {
+      "name": "Redirect /primitives",
+      "match": "/primitives",
+      "destination": "https://primer.style/primitives/storybook/"
     }
   ]
 }

--- a/redirects.json
+++ b/redirects.json
@@ -134,8 +134,8 @@
     },
     {
       "name": "Redirect /primitives/spacing",
-      "match": "/primitives/spacing",
-      "destination": "https://primer.style/primitives/storybook/?path=/story/size-base--base"
+      "match": "primitives/spacing",
+      "destination": "/primitives/storybook/?path=/story/size-base--base"
     },
     {
       "name": "Redirect /primitives/typography",

--- a/redirects.json
+++ b/redirects.json
@@ -129,8 +129,8 @@
     },
     {
       "name": "Redirect /primitives/colors",
-      "match": "/primitives/colors",
-      "destination": "https://primer.style/design/foundations/color"
+      "match": "primitives/colors",
+      "destination": "/design/foundations/color"
     },
     {
       "name": "Redirect /primitives/spacing",

--- a/redirects.json
+++ b/redirects.json
@@ -139,8 +139,8 @@
     },
     {
       "name": "Redirect /primitives/typography",
-      "match": "/primitives/typography",
-      "destination": "https://primer.style/primitives/storybook/?path=/story/typography-base--base"
+      "match": "primitives/typography",
+      "destination": "/primitives/storybook/?path=/story/typography-base--base"
     },
     {
       "name": "Redirect /primitives",

--- a/redirects.json
+++ b/redirects.json
@@ -39,6 +39,26 @@
       "name": "Redirect /octicons/*",
       "match": "(octicons)(.*)",
       "destination": "/design/foundations/icons{R:2}"
+    },
+    {
+      "name": "Redirect /primitives/colors",
+      "match": "primitives/colors",
+      "destination": "/design/foundations/color"
+    },
+    {
+      "name": "Redirect /primitives/spacing",
+      "match": "primitives/spacing",
+      "destination": "/primitives/storybook/?path=/story/size-base--base"
+    },
+    {
+      "name": "Redirect /primitives/typography",
+      "match": "primitives/typography",
+      "destination": "/primitives/storybook/?path=/story/typography-base--base"
+    },
+    {
+      "name": "Redirect /primitives",
+      "match": "^primitives/?$",
+      "destination": "/primitives/storybook/"
     }
   ],
   "rewrites": [
@@ -89,8 +109,8 @@
     },
     {
       "name": "Primitives proxy",
-      "match": "^primitives/(.*)",
-      "destination": "https://primer.github.io/primitives/{R:1}"
+      "match": "^primitives/storybook/(.*)",
+      "destination": "https://primer.github.io/primitives/storybook/{R:1}"
     },
     {
       "name": "Mobile proxy",
@@ -126,26 +146,6 @@
       "name": "CSS reverse-proxy",
       "match": "^css/(.*)",
       "destination": "https://primer.github.io/css/{R:1}"
-    },
-    {
-      "name": "Redirect /primitives/colors",
-      "match": "primitives/colors",
-      "destination": "/design/foundations/color"
-    },
-    {
-      "name": "Redirect /primitives/spacing",
-      "match": "primitives/spacing",
-      "destination": "/primitives/storybook/?path=/story/size-base--base"
-    },
-    {
-      "name": "Redirect /primitives/typography",
-      "match": "primitives/typography",
-      "destination": "/primitives/storybook/?path=/story/typography-base--base"
-    },
-    {
-      "name": "Redirect /primitives",
-      "match": "^primitives/?$",
-      "destination": "/primitives/storybook/"
     }
   ]
 }


### PR DESCRIPTION
Setting up redirects before we remove the gatsby docs from primer/primitives. Some of these links go directly to Storybook for now, but will eventually be reflected in /design docs.

I have no idea if I did this correctly 😄 

Part of https://github.com/github/primer/issues/2153