### PR TITLE
Use OIDC creds to deploy

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -7,6 +7,10 @@ on:
 
   workflow_dispatch:
 
+permissions:
+  id-token: write
+  contents: read
+
 jobs:
   build:
     runs-on: ubuntu-latest
@@ -46,6 +50,13 @@ jobs:
       url: ${{ steps.deploy-to-webapp.outputs.webapp-url }}
 
     steps:
+      - name: Az CLI login
+        uses: azure/login@v1
+        with:
+          client-id: d1121761-5bcf-486b-aff0-e6451b4f4e05
+          tenant-id: 398a6654-997b-47e9-b12b-9515b896b4de
+          subscription-id: 550eb99d-d0c7-4651-a337-f53fa6520c4f
+
       - name: Download artifact from build job
         uses: actions/download-artifact@v2
         with:
@@ -57,5 +68,4 @@ jobs:
         with:
           app-name: 'primerstyle'
           slot-name: 'production'
-          publish-profile: ${{ secrets.AZURE_PUBLISH_PROFILE }}
           package: .

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -53,9 +53,9 @@ jobs:
       - name: Az CLI login
         uses: azure/login@v1
         with:
-          client-id: d1121761-5bcf-486b-aff0-e6451b4f4e05
-          tenant-id: 398a6654-997b-47e9-b12b-9515b896b4de
-          subscription-id: 550eb99d-d0c7-4651-a337-f53fa6520c4f
+          client-id: ${{ secrets.AZURE_CLIENT_ID }}
+          tenant-id: ${{ secrets.AZURE_TENANT_ID }}
+          subscription-id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
 
       - name: Download artifact from build job
         uses: actions/download-artifact@v2

--- a/.github/workflows/deploy_staging.yml
+++ b/.github/workflows/deploy_staging.yml
@@ -46,6 +46,13 @@ jobs:
       url: ${{ steps.deploy-to-webapp.outputs.webapp-url }}
 
     steps:
+      - name: Az CLI login
+        uses: azure/login@v1
+        with:
+          client-id: ${{ secrets.AZURE_CLIENT_ID }}
+          tenant-id: ${{ secrets.AZURE_TENANT_ID }}
+          subscription-id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
+
       - name: Download artifact from build job
         uses: actions/download-artifact@v2
         with:
@@ -57,5 +64,4 @@ jobs:
         with:
           app-name: 'primerstyle'
           slot-name: 'staging'
-          publish-profile: ${{ secrets.AZURE_PUBLISH_PROFILE_STAGING }}
           package: .

--- a/.github/workflows/deploy_staging.yml
+++ b/.github/workflows/deploy_staging.yml
@@ -53,7 +53,7 @@ jobs:
       - name: Az CLI login
         uses: azure/login@v1
         with:
-          client-id: ${{ secrets.AZURE_CLIENT_ID }}
+          client-id: ${{ secrets.AZURE_STAGING_CLIENT_ID }}
           tenant-id: ${{ secrets.AZURE_TENANT_ID }}
           subscription-id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
 

--- a/.github/workflows/deploy_staging.yml
+++ b/.github/workflows/deploy_staging.yml
@@ -7,6 +7,10 @@ on:
 
   workflow_dispatch:
 
+permissions:
+  id-token: write
+  contents: read
+
 jobs:
   build:
     runs-on: ubuntu-latest


### PR DESCRIPTION
This PR performs deploys using federated OIDC credentials in favor of the existing basic auth-based publish profile. Can confirm it works for prod deploys 👍 

See also:

1. Terraform change to create a new service principal (SPN): https://github.com/github/azure-rbac/pull/945
2. Terraform change to give the new SPN access to our subscription: https://github.com/github/azure-rbac/pull/946