### PR TITLE
Revert "Redirection `/` → `/design`"

### DIFF
--- a/redirects.json
+++ b/redirects.json
@@ -254,11 +254,6 @@
       "name": "ViewComponents docs for Primer::Alpha::ToggleSwitch",
       "match": "^view-components/components/alpha/toggleswitch",
       "destination": "/design/components/toggle-switch"
-    },
-    {
-      "name": "Redirect / → /design",
-      "match": "^/",
-      "destination": "/design"
     }
   ],
   "rewrites": [


### PR DESCRIPTION
Reverts primer/primer.style#367

The redirect doesn't appear to do anything. `primer.style` does not redirect to `primer.style/design`