### PR TITLE
Add Primer CSS redirects

### DIFF
--- a/redirects.json
+++ b/redirects.json
@@ -259,6 +259,71 @@
       "name": "Redirect /",
       "match": "^$",
       "destination": "/design"
+    },
+    {
+      "name": "Redirect /css to Storybook",
+      "match": "^css/?$",
+      "destination": "/css/storybook/"
+    },
+    {
+      "name": "CSS Utilities",
+      "match": "^css/utilities",
+      "destination": "/design/foundations/css-utilities/getting-started"
+    },
+    {
+      "name": "CSS Utilities: animations",
+      "match": "^css/utilities/animations",
+      "destination": "/design/foundations/css-utilities/animations"
+    },
+    {
+      "name": "CSS Utilities: borders",
+      "match": "^css/utilities/borders",
+      "destination": "/design/foundations/css-utilities/borders"
+    },
+    {
+      "name": "CSS Utilities: box-shadow",
+      "match": "^css/utilities/box-shadow",
+      "destination": "/design/foundations/css-utilities/box-shadow"
+    },
+    {
+      "name": "CSS Utilities: colors",
+      "match": "^css/utilities/colors",
+      "destination": "/design/foundations/css-utilities/colors"
+    },
+    {
+      "name": "CSS Utilities: details",
+      "match": "^css/utilities/details",
+      "destination": "/design/foundations/css-utilities/details"
+    },
+    {
+      "name": "CSS Utilities: flexbox",
+      "match": "^css/utilities/flexbox",
+      "destination": "/design/foundations/css-utilities/flexbox"
+    },
+    {
+      "name": "CSS Utilities: grid",
+      "match": "^css/utilities/grid",
+      "destination": "/design/foundations/css-utilities/grid"
+    },
+    {
+      "name": "CSS Utilities: layout",
+      "match": "^css/utilities/layout",
+      "destination": "/design/foundations/css-utilities/layout"
+    },
+    {
+      "name": "CSS Utilities: margin",
+      "match": "^css/utilities/margin",
+      "destination": "/design/foundations/css-utilities/margin"
+    },
+    {
+      "name": "CSS Utilities: padding",
+      "match": "^css/utilities/padding",
+      "destination": "/design/foundations/css-utilities/padding"
+    },
+    {
+      "name": "CSS Utilities: typography",
+      "match": "^css/utilities/typography",
+      "destination": "/design/foundations/css-utilities/typography"
     }
   ],
   "rewrites": [

--- a/redirects.json
+++ b/redirects.json
@@ -269,61 +269,6 @@
       "name": "CSS Utilities",
       "match": "^css/utilities",
       "destination": "/design/foundations/css-utilities/getting-started"
-    },
-    {
-      "name": "CSS Utilities: animations",
-      "match": "^css/utilities/animations",
-      "destination": "/design/foundations/css-utilities/animations"
-    },
-    {
-      "name": "CSS Utilities: borders",
-      "match": "^css/utilities/borders",
-      "destination": "/design/foundations/css-utilities/borders"
-    },
-    {
-      "name": "CSS Utilities: box-shadow",
-      "match": "^css/utilities/box-shadow",
-      "destination": "/design/foundations/css-utilities/box-shadow"
-    },
-    {
-      "name": "CSS Utilities: colors",
-      "match": "^css/utilities/colors",
-      "destination": "/design/foundations/css-utilities/colors"
-    },
-    {
-      "name": "CSS Utilities: details",
-      "match": "^css/utilities/details",
-      "destination": "/design/foundations/css-utilities/details"
-    },
-    {
-      "name": "CSS Utilities: flexbox",
-      "match": "^css/utilities/flexbox",
-      "destination": "/design/foundations/css-utilities/flexbox"
-    },
-    {
-      "name": "CSS Utilities: grid",
-      "match": "^css/utilities/grid",
-      "destination": "/design/foundations/css-utilities/grid"
-    },
-    {
-      "name": "CSS Utilities: layout",
-      "match": "^css/utilities/layout",
-      "destination": "/design/foundations/css-utilities/layout"
-    },
-    {
-      "name": "CSS Utilities: margin",
-      "match": "^css/utilities/margin",
-      "destination": "/design/foundations/css-utilities/margin"
-    },
-    {
-      "name": "CSS Utilities: padding",
-      "match": "^css/utilities/padding",
-      "destination": "/design/foundations/css-utilities/padding"
-    },
-    {
-      "name": "CSS Utilities: typography",
-      "match": "^css/utilities/typography",
-      "destination": "/design/foundations/css-utilities/typography"
     }
   ],
   "rewrites": [

--- a/redirects.json
+++ b/redirects.json
@@ -409,8 +409,8 @@
     },
     {
       "name": "CSS reverse-proxy",
-      "match": "^css/(.*)",
-      "destination": "https://primer.github.io/css/{R:1}"
+      "match": "^css/storybook/(.*)",
+      "destination": "https://primer.github.io/css/storybook/{R:1}"
     }
   ]
 }


### PR DESCRIPTION
Gatsby docs for Primer CSS have all moved to Storybook. This adds a root redirect to Storybook, but also tries to direct traffic for utility docs to /design. 

Do I need to add a redirect for every single page in Primer CSS docs?

**Testing**

I pushed this to staging:

https://primerstyle-staging.azurewebsites.net/css should render Storybook
https://primerstyle-staging.azurewebsites.net/css/utilities should render /design site