### PR TITLE
Redirect PVC root

### DIFF
--- a/redirects.json
+++ b/redirects.json
@@ -61,6 +61,11 @@
       "destination": "/primitives/storybook/"
     },
     {
+      "name": "Redirect /view-components root",
+      "match": "^view-components/$",
+      "destination": "/design"
+    },
+    {
       "name": "ViewComponents docs for Primer::Alpha::ActionList",
       "match": "^view-components/components/alpha/actionlist",
       "destination": "/design/components/action-list/rails/alpha"
@@ -351,11 +356,6 @@
       "destination": "https://github.com/primer/view_components/blob/main/docs/contributors/linting.md"
     },
     {
-      "name": "Redirect /view-components root",
-      "match": "^/view-components/",
-      "destination": "/design"
-    },
-    {
       "name": "Redirect /",
       "match": "^$",
       "destination": "/design"
@@ -391,11 +391,6 @@
       "name": "ViewComponents Rails App proxy",
       "match": "^view-components/rails-app/(.*)",
       "destination": "https://view-components-storybook.eastus.cloudapp.azure.com/view-components/rails-app/{R:1}"
-    },
-    {
-      "name": "ViewComponents proxy",
-      "match": "^view-components/(.*)",
-      "destination": "https://primer.github.io/view_components/{R:1}"
     },
     {
       "name": "Design proxy",

--- a/redirects.json
+++ b/redirects.json
@@ -351,6 +351,11 @@
       "destination": "https://github.com/primer/view_components/blob/main/docs/contributors/linting.md"
     },
     {
+      "name": "Redirect /view-components root",
+      "match": "^/view-components/",
+      "destination": "/design"
+    },
+    {
       "name": "Redirect /",
       "match": "^$",
       "destination": "/design"


### PR DESCRIPTION
We have redirects for /view-components/*, but not for the /view-components/ root itself.

Verified this works in staging 👍 