### PR TITLE
Add redirect for tooltip alternative docs

### DIFF
--- a/redirects.json
+++ b/redirects.json
@@ -369,6 +369,11 @@
       "name": "CSS Utilities",
       "match": "^css/utilities",
       "destination": "/design/foundations/css-utilities/getting-started"
+    },
+    {
+      "name": "Redirect tooltip alternatives",
+      "match": "/design/accessibility/tooltip-alternatives",
+      "destination": "/design/components/tooltip#alternatives-to-tooltips"
     }
   ],
   "rewrites": [


### PR DESCRIPTION
Redirect to the new `Tooltip` docs page