### PR TITLE
Native redirects

### DIFF
--- a/redirects.json
+++ b/redirects.json
@@ -369,6 +369,191 @@
       "name": "CSS Utilities",
       "match": "^css/utilities",
       "destination": "/design/foundations/css-utilities/getting-started"
+    },
+    {
+      "name": "Native Desktop - Getting started",
+      "match": "^desktop$",
+      "destination": "/design/native/desktop/getting-started"
+    },
+    {
+      "name": "Native Desktop - Foundations - Relationship to Primer Web",
+      "match": "^desktop/foundations/relationshiptoprimerweb",
+      "destination": "/design/native/desktop/foundations#relationship-to-primer-web"
+    },
+    {
+      "name": "Native Desktop - Foundations - Color",
+      "match": "^desktop/foundations/color",
+      "destination": "/design/native/desktop/foundations#color"
+    },
+    {
+      "name": "Native Desktop - Foundations - Typography",
+      "match": "^desktop/foundations/typography",
+      "destination": "/design/native/desktop/foundations#typography"
+    },
+    {
+      "name": "Native Desktop - Foundations - Iconography",
+      "match": "^desktop/foundations/iconography",
+      "destination": "/design/native/desktop/foundations#iconography"
+    },
+    {
+      "name": "Native Desktop - Foundations - Illustrations",
+      "match": "^desktop/foundations/illustrations",
+      "destination": "/design/native/desktop/foundations#illustrations"
+    },
+    {
+      "name": "Native Desktop - Foundations - Platforms",
+      "match": "^desktop/foundations/platforms",
+      "destination": "/design/native/desktop/foundations#platforms"
+    },
+    {
+      "name": "Native Desktop - Foundations - Spacing",
+      "match": "^desktop/foundations/spacing",
+      "destination": "/design/native/desktop/foundations#spacing"
+    },
+    {
+      "name": "Native Desktop - Foundations - System Elements",
+      "match": "^desktop/foundations/systemelements",
+      "destination": "/design/native/desktop/foundations"
+    },
+    {
+      "name": "Native CLI - Getting Started",
+      "match": "^cli$",
+      "destination": "/design/native/cli/getting-started"
+    },
+    {
+      "name": "Native CLI - Principles",
+      "match": "^cli/getting-started/principles",
+      "destination": "/design/native/cli/getting-started#principles"
+    },
+    {
+      "name": "Native CLI - Process",
+      "match": "^cli/getting-started/process",
+      "destination": "/design/native/cli/getting-started#process"
+    },
+    {
+      "name": "Native CLI - Prototyping",
+      "match": "^cli/getting-started/prototyping",
+      "destination": "/design/native/cli/getting-started#prototyping"
+    },
+    {
+      "name": "Native CLI - Foundations - Language",
+      "match": "^cli/foundations/language",
+      "destination": "/design/native/cli/foundations#language"
+    },
+    {
+      "name": "Native CLI - Foundations - Typography",
+      "match": "^cli/foundations/typography",
+      "destination": "/design/native/cli/foundations#typography"
+    },
+    {
+      "name": "Native CLI - Foundations - Spacing",
+      "match": "^cli/foundations/spacing",
+      "destination": "/design/native/cli/foundations#spacing"
+    },
+    {
+      "name": "Native CLI - Foundations - Color",
+      "match": "^cli/foundations/color",
+      "destination": "/design/native/cli/foundations#color"
+    },
+    {
+      "name": "Native CLI - Foundations - Iconography",
+      "match": "^cli/foundations/iconography",
+      "destination": "/design/native/cli/foundations#iconography"
+    },
+    {
+      "name": "Native CLI - Foundations - Scriptability",
+      "match": "^cli/foundations/scriptability",
+      "destination": "/design/native/cli/foundations#scriptability"
+    },
+    {
+      "name": "Native CLI - Foundations - Customizability",
+      "match": "^cli/foundations/customizability",
+      "destination": "/design/native/cli/foundations#customizability"
+    },
+    {
+      "name": "Native CLI - Components - Syntax",
+      "match": "^cli/components/syntax",
+      "destination": "/design/native/cli/components#syntax"
+    },
+    {
+      "name": "Native CLI - Components - Prompts",
+      "match": "^cli/components/prompts",
+      "destination": "/design/native/cli/components#prompts"
+    },
+    {
+      "name": "Native CLI - Components - State",
+      "match": "^cli/components/state",
+      "destination": "/design/native/cli/components#state"
+    },
+    {
+      "name": "Native CLI - Components - Progress indicators",
+      "match": "^cli/components/progress",
+      "destination": "/design/native/cli/components#progress-indicators"
+    },
+    {
+      "name": "Native CLI - Components - Headers",
+      "match": "^cli/components/headers",
+      "destination": "/design/native/cli/components#headers"
+    },
+    {
+      "name": "Native CLI - Components - Prompts",
+      "match": "^cli/components/lists",
+      "destination": "/design/native/cli/components#lists"
+    },
+    {
+      "name": "Native CLI - Components - Detail views",
+      "match": "^cli/components/detail",
+      "destination": "/design/native/cli/components#detail-views"
+    },
+    {
+      "name": "Native CLI - Components - Empty states",
+      "match": "^cli/components/empty",
+      "destination": "/design/native/cli/components#empty-states"
+    },
+    {
+      "name": "Native CLI - Components - Help pages",
+      "match": "^cli/components/help",
+      "destination": "/design/native/cli/components#help-pages"
+    },
+    {
+      "name": "Native Mobile",
+      "match": "^mobile$",
+      "destination": "/design/native/mobile"
+    },
+    {
+      "name": "Native Mobile - Platforms",
+      "match": "^mobile/platforms",
+      "destination": "/design/native/mobile/platforms"
+    },
+    {
+      "name": "Native Mobile - Platforms - iOS and iPadOS",
+      "match": "^mobile/platforms/ios",
+      "destination": "/design/native/mobile/platforms#ios-and-ipados"
+    },
+    {
+      "name": "Native Mobile - Platforms - Android",
+      "match": "^mobile/platforms/android",
+      "destination": "/design/native/mobile/platforms#android"
+    },
+    {
+      "name": "Native Mobile - Foundations",
+      "match": "^mobile/foundations",
+      "destination": "/design/native/mobile/foundations"
+    },
+    {
+      "name": "Native Mobile - Foundations - Spacing and layout",
+      "match": "^mobile/foundations/spacing-layout",
+      "destination": "/design/native/mobile/foundations#spacing-and-layout"
+    },
+    {
+      "name": "Native Mobile - Foundations - Color",
+      "match": "^mobile/foundations/iconography",
+      "destination": "/design/native/mobile/foundations#iconography"
+    },
+    {
+      "name": "Native Mobile - Foundations - Typography",
+      "match": "^mobile/foundations/typography",
+      "destination": "/design/native/mobile/foundations#typography"
     }
   ],
   "rewrites": [

--- a/redirects.json
+++ b/redirects.json
@@ -372,7 +372,7 @@
     },
     {
       "name": "Native Desktop - Getting started",
-      "match": "^desktop$",
+      "match": "^desktop/?$",
       "destination": "/design/native/desktop/getting-started"
     },
     {
@@ -417,7 +417,7 @@
     },
     {
       "name": "Native CLI - Getting Started",
-      "match": "^cli$",
+      "match": "^cli/?$",
       "destination": "/design/native/cli/getting-started"
     },
     {
@@ -517,7 +517,7 @@
     },
     {
       "name": "Native Mobile",
-      "match": "^mobile$",
+      "match": "^mobile/?$",
       "destination": "/design/native/mobile"
     },
     {
@@ -593,19 +593,9 @@
       "destination": "https://primer.github.io/doctocat/{R:1}"
     },
     {
-      "name": "CLI proxy",
-      "match": "^cli/(.*)",
-      "destination": "https://primer.github.io/cli/{R:1}"
-    },
-    {
       "name": "Primitives proxy",
       "match": "^primitives/storybook/(.*)",
       "destination": "https://primer.github.io/primitives/storybook/{R:1}"
-    },
-    {
-      "name": "Mobile proxy",
-      "match": "^mobile/(.*)",
-      "destination": "https://primer.github.io/mobile/{R:1}"
     },
     {
       "name": "Brand Storybook proxy",
@@ -616,11 +606,6 @@
       "name": "Brand proxy",
       "match": "^brand/(.*)",
       "destination": "https://primer.github.io/brand/{R:1}"
-    },
-    {
-      "name": "Desktop proxy",
-      "match": "^desktop/(.*)",
-      "destination": "https://primer.github.io/desktop/{R:1}"
     },
     {
       "name": "Contribute proxy",

--- a/redirects.json
+++ b/redirects.json
@@ -378,37 +378,37 @@
     {
       "name": "Native Desktop - Foundations - Relationship to Primer Web",
       "match": "^desktop/foundations/relationshiptoprimerweb",
-      "destination": "/design/native/desktop/foundations#relationship-to-primer-web"
+      "destination": "/design/native/desktop/foundations/?anchor=relationship-to-primer-web"
     },
     {
       "name": "Native Desktop - Foundations - Color",
       "match": "^desktop/foundations/color",
-      "destination": "/design/native/desktop/foundations#color"
+      "destination": "/design/native/desktop/foundations/?anchor=color"
     },
     {
       "name": "Native Desktop - Foundations - Typography",
       "match": "^desktop/foundations/typography",
-      "destination": "/design/native/desktop/foundations#typography"
+      "destination": "/design/native/desktop/foundations/?anchor=typography"
     },
     {
       "name": "Native Desktop - Foundations - Iconography",
       "match": "^desktop/foundations/iconography",
-      "destination": "/design/native/desktop/foundations#iconography"
+      "destination": "/design/native/desktop/foundations/?anchor=iconography"
     },
     {
       "name": "Native Desktop - Foundations - Illustrations",
       "match": "^desktop/foundations/illustrations",
-      "destination": "/design/native/desktop/foundations#illustrations"
+      "destination": "/design/native/desktop/foundations/?anchor=illustrations"
     },
     {
       "name": "Native Desktop - Foundations - Platforms",
       "match": "^desktop/foundations/platforms",
-      "destination": "/design/native/desktop/foundations#platforms"
+      "destination": "/design/native/desktop/foundations/?anchor=platforms"
     },
     {
       "name": "Native Desktop - Foundations - Spacing",
       "match": "^desktop/foundations/spacing",
-      "destination": "/design/native/desktop/foundations#spacing"
+      "destination": "/design/native/desktop/foundations/?anchor=spacing"
     },
     {
       "name": "Native Desktop - Foundations - System Elements",
@@ -423,97 +423,97 @@
     {
       "name": "Native CLI - Principles",
       "match": "^cli/getting-started/principles",
-      "destination": "/design/native/cli/getting-started#principles"
+      "destination": "/design/native/cli/getting-started/?anchor=principles"
     },
     {
       "name": "Native CLI - Process",
       "match": "^cli/getting-started/process",
-      "destination": "/design/native/cli/getting-started#process"
+      "destination": "/design/native/cli/getting-started/?anchor=process"
     },
     {
       "name": "Native CLI - Prototyping",
       "match": "^cli/getting-started/prototyping",
-      "destination": "/design/native/cli/getting-started#prototyping"
+      "destination": "/design/native/cli/getting-started/?anchor=prototyping"
     },
     {
       "name": "Native CLI - Foundations - Language",
       "match": "^cli/foundations/language",
-      "destination": "/design/native/cli/foundations#language"
+      "destination": "/design/native/cli/foundations/?anchor=language"
     },
     {
       "name": "Native CLI - Foundations - Typography",
       "match": "^cli/foundations/typography",
-      "destination": "/design/native/cli/foundations#typography"
+      "destination": "/design/native/cli/foundations/?anchor=typography"
     },
     {
       "name": "Native CLI - Foundations - Spacing",
       "match": "^cli/foundations/spacing",
-      "destination": "/design/native/cli/foundations#spacing"
+      "destination": "/design/native/cli/foundations/?anchor=spacing"
     },
     {
       "name": "Native CLI - Foundations - Color",
       "match": "^cli/foundations/color",
-      "destination": "/design/native/cli/foundations#color"
+      "destination": "/design/native/cli/foundations/?anchor=color"
     },
     {
       "name": "Native CLI - Foundations - Iconography",
       "match": "^cli/foundations/iconography",
-      "destination": "/design/native/cli/foundations#iconography"
+      "destination": "/design/native/cli/foundations/?anchor=iconography"
     },
     {
       "name": "Native CLI - Foundations - Scriptability",
       "match": "^cli/foundations/scriptability",
-      "destination": "/design/native/cli/foundations#scriptability"
+      "destination": "/design/native/cli/foundations/?anchor=scriptability"
     },
     {
       "name": "Native CLI - Foundations - Customizability",
       "match": "^cli/foundations/customizability",
-      "destination": "/design/native/cli/foundations#customizability"
+      "destination": "/design/native/cli/foundations/?anchor=customizability"
     },
     {
       "name": "Native CLI - Components - Syntax",
       "match": "^cli/components/syntax",
-      "destination": "/design/native/cli/components#syntax"
+      "destination": "/design/native/cli/components/?anchor=syntax"
     },
     {
       "name": "Native CLI - Components - Prompts",
       "match": "^cli/components/prompts",
-      "destination": "/design/native/cli/components#prompts"
+      "destination": "/design/native/cli/components/?anchor=prompts"
     },
     {
       "name": "Native CLI - Components - State",
       "match": "^cli/components/state",
-      "destination": "/design/native/cli/components#state"
+      "destination": "/design/native/cli/components/?anchor=state"
     },
     {
       "name": "Native CLI - Components - Progress indicators",
       "match": "^cli/components/progress",
-      "destination": "/design/native/cli/components#progress-indicators"
+      "destination": "/design/native/cli/components/?anchor=progress-indicators"
     },
     {
       "name": "Native CLI - Components - Headers",
       "match": "^cli/components/headers",
-      "destination": "/design/native/cli/components#headers"
+      "destination": "/design/native/cli/components/?anchor=headers"
     },
     {
-      "name": "Native CLI - Components - Prompts",
+      "name": "Native CLI - Components - Lists",
       "match": "^cli/components/lists",
-      "destination": "/design/native/cli/components#lists"
+      "destination": "/design/native/cli/components/?anchor=lists"
     },
     {
       "name": "Native CLI - Components - Detail views",
       "match": "^cli/components/detail",
-      "destination": "/design/native/cli/components#detail-views"
+      "destination": "/design/native/cli/components/?anchor=detail-views"
     },
     {
       "name": "Native CLI - Components - Empty states",
       "match": "^cli/components/empty",
-      "destination": "/design/native/cli/components#empty-states"
+      "destination": "/design/native/cli/components/?anchor=empty-states"
     },
     {
       "name": "Native CLI - Components - Help pages",
       "match": "^cli/components/help",
-      "destination": "/design/native/cli/components#help-pages"
+      "destination": "/design/native/cli/components/?anchor=help-pages"
     },
     {
       "name": "Native Mobile",


### PR DESCRIPTION
This PR introduces a number of redirects from three legacy docsites to their /design counterparts: https://primer.style/cli/, https://primer.style/mobile/, and https://primer.style/desktop/. The legacy docsites were broken up into individual pages while the new docsites have combined entire sections into single pages. For that reason, rewriting legacy URLs to new docsite URLs makes use of [functionality](https://github.com/primer/design/pull/610) recently added to primer/design that allows linking to a specific anchor on the page.

Fixes https://github.com/github/primer/issues/1703
Fixes https://github.com/github/primer/issues/1702
Fixes https://github.com/github/primer/issues/1701