### PR TITLE
Fix /design redirect

### DIFF
--- a/redirects.json
+++ b/redirects.json
@@ -7,7 +7,7 @@
     },
     {
       "name": "Redirect /design",
-      "match": "design(.*)",
+      "match": "^design(.*)",
       "destination": "{R:1}"
     },
     {


### PR DESCRIPTION
On https://primer.style/, the link to "Design guidelines" under "Icons and visuals" redirects to https://primer.style/-guidelines/, which is a 404 🤯  This is happening because of an over-eager regex meant to redirect old /design URLs that looks for the text "design" anywhere in the string instead of only at the beginning. I have deployed to staging and confirmed this PR fixes the issue.