### PR TITLE
Add redirects for `/react` sub-site

### DIFF
--- a/redirects.json
+++ b/redirects.json
@@ -337,6 +337,62 @@
     },
 
     {
+      "name": "React index redirect to guides",
+      "match": "^react/",
+      "destination": "/guides/react"
+    },
+    {
+      "name": "React redirect getting started",
+      "match": "^react/getting-started",
+      "destination": "/guides/react"
+    },
+    {
+      "name": "React redirect TODO",
+      "match": "^react/theming",
+      "destination": "TODO"
+    },
+    {
+      "name": "React redirect TODO",
+      "match": "^react/theme-reference",
+      "destination": "TODO"
+    },
+    {
+      "name": "React redirect TODO",
+      "match": "^react/linting",
+      "destination": "TODO"
+    },
+    {
+      "name": "React redirect TODO",
+      "match": "^react/system-props",
+      "destination": "TODO"
+    },
+    {
+      "name": "React redirect TODO",
+      "match": "^react/core-concepts",
+      "destination": "TODO"
+    },
+    {
+      "name": "React redirect TODO",
+      "match": "^react/philosophy",
+      "destination": "TODO"
+    },
+    {
+      "name": "React redirect TODO",
+      "match": "^react/overriding-styles",
+      "destination": "TODO"
+    },
+    {
+      "name": "React redirect TODO",
+      "match": "^react/status",
+      "destination": "TODO"
+    },
+    {
+      "name": "React redirect TODO",
+      "match": "^react/hooks/useSafeTimeout",
+      "destination": "TODO"
+    },
+
+    {
       "name": "React docs for ActionList",
       "match": "^react/ActionList",
       "destination": "/components/action-list/react"

--- a/redirects.json
+++ b/redirects.json
@@ -966,6 +966,11 @@
       "destination": "https://primer.github.io/css/storybook/{R:1}"
     },
     {
+      "name": "React Storybook reverse-proxy",
+      "match": "^react/storybook/(.*)",
+      "destination": "https://primer.github.io/react/storybook/{R:1}"
+    },
+    {
       "name": "Design proxy",
       "match": "^/?(.*)",
       "destination": "https://primer.github.io/design/{R:1}"

--- a/redirects.json
+++ b/redirects.json
@@ -347,49 +347,49 @@
       "destination": "/guides/react"
     },
     {
-      "name": "React redirect TODO",
+      "name": "React redirect theming",
       "match": "^react/theming",
-      "destination": "TODO"
+      "destination": "/guides/react/theming"
     },
     {
-      "name": "React redirect TODO",
+      "name": "React redirect theme reference",
       "match": "^react/theme-reference",
-      "destination": "TODO"
+      "destination": "/guides/react/theme-reference"
     },
     {
-      "name": "React redirect TODO",
+      "name": "React redirect linting",
       "match": "^react/linting",
-      "destination": "TODO"
+      "destination": "/guides/react/linting"
     },
     {
-      "name": "React redirect TODO",
+      "name": "React redirect system props",
       "match": "^react/system-props",
-      "destination": "TODO"
+      "destination": "/guides/react/system-props"
     },
     {
-      "name": "React redirect TODO",
+      "name": "React redirect core concepts",
       "match": "^react/core-concepts",
-      "destination": "TODO"
+      "destination": "/guides/react/core-concepts"
     },
     {
-      "name": "React redirect TODO",
+      "name": "React redirect philosophy",
       "match": "^react/philosophy",
-      "destination": "TODO"
+      "destination": "/guides/react/philosophy"
     },
     {
-      "name": "React redirect TODO",
+      "name": "React redirect overriding styles",
       "match": "^react/overriding-styles",
-      "destination": "TODO"
+      "destination": "/guides/react/overriding-styles"
     },
     {
-      "name": "React redirect TODO",
+      "name": "React redirect status",
       "match": "^react/status",
-      "destination": "TODO"
+      "destination": "/guides/status"
     },
     {
-      "name": "React redirect TODO",
+      "name": "React redirect useSafeTimeout hook",
       "match": "^react/hooks/useSafeTimeout",
-      "destination": "TODO"
+      "destination": "/guides/react/hooks/use-safe-timeout"
     },
 
     {
@@ -959,11 +959,6 @@
       "name": "Prism proxy",
       "match": "^prism/(.*)",
       "destination": "https://primer.github.io/prism/{R:1}"
-    },
-    {
-      "name": "React reverse-proxy",
-      "match": "^react/(.*)",
-      "destination": "https://primer.github.io/react/{R:1}"
     },
     {
       "name": "CSS reverse-proxy",

--- a/redirects.json
+++ b/redirects.json
@@ -337,9 +337,9 @@
     },
 
     {
-      "name": "React index redirect to guides",
+      "name": "React index redirect to site index",
       "match": "^react/",
-      "destination": "/guides/react"
+      "destination": "/"
     },
     {
       "name": "React redirect getting started",

--- a/redirects.json
+++ b/redirects.json
@@ -337,8 +337,8 @@
     },
 
     {
-      "name": "React index redirect to site index",
-      "match": "^react/",
+      "name": "Redirect react root",
+      "match": "^react/$",
       "destination": "/"
     },
     {


### PR DESCRIPTION
First part of https://github.com/github/primer/issues/3334

| From | To |
| :--- | :-- |
| /react | / |
| /react/getting-started | /guides/react |
| /react/theming | /guides/react/theming |
| /react/theme-reference | /guides/react/theme-reference |
| /react/linting | /guides/react/linting |
| /react/system-props | /guides/react/system-props |
| /react/core-concepts | /guides/react/core-concepts |
| /react/philosophy | /guides/react/philosophy |
| /react/overriding-styles | /guides/react/overriding-styles |
| /react/status | /guides/status |
| /react/hooks/useSafeTimeout | /guides/react/hooks/use-safe-timeout |