### PR TITLE
Fix pvc asset redirects

### DIFF
--- a/.github/workflows/deploy_staging.yml
+++ b/.github/workflows/deploy_staging.yml
@@ -37,7 +37,7 @@ jobs:
           cp web.config public/
 
       - name: Upload artifact for deployment job
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         with:
           name: node-app
           path: ./public/
@@ -58,7 +58,7 @@ jobs:
           subscription-id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
 
       - name: Download artifact from build job
-        uses: actions/download-artifact@v2
+        uses: actions/download-artifact@v4
         with:
           name: node-app
 

--- a/redirects.json
+++ b/redirects.json
@@ -911,6 +911,11 @@
       "destination": "https://primer-lookbook.github.com/assets/{R:1}"
     },
     {
+      "name": "ViewComponents Preview assets proxy (Vite)",
+      "match": "^vite/assets/(.*)",
+      "destination": "https://primer-lookbook.github.com/vite/assets/{R:1}"
+    },
+    {
       "name": "ViewComponents Lookbook assets proxy",
       "match": "^lookbook-assets/(.*)",
       "destination": "https://primer-lookbook.github.com/lookbook-assets/{R:1}"


### PR DESCRIPTION
PVC's Lookbook recently moved to Vite, which exposes assets at a different path than before. This PR adds a redirect for the new path. Confirmed working in staging.