### PR TITLE
Add url rewrite for /octovisuals

### DIFF
--- a/redirects.json
+++ b/redirects.json
@@ -1573,6 +1573,11 @@
       "destination": "https://primer.github.io/react/storybook/{R:1}"
     },
     {
+      "name": "Octovisuals proxy",
+      "match": "^octovisuals/(.*)",
+      "destination": "https://primer.github.io/octovisuals/{R:1}"
+    },
+    {
       "name": "Design proxy",
       "match": "^/?(.*)",
       "destination": "https://primer-docs-preview.github.com/{R:1}"


### PR DESCRIPTION
Adds a new URL rewrite to our reverse proxy configuration for the new Octovisuals project. 

Origin URL: https://primer.github.io/octovisuals
Proposed rewrite: primer.style/octovisuals

This is the same approach we use for all other URL rewrites. 

Tested and validated in staging:

🔗 [Staging preview](https://primerstyle-staging.azurewebsites.net/octovisuals/)