### PR TITLE
Update redirects.json from primer-docs rules.ts and remove Contribute proxy

### DIFF
--- a/redirects.json
+++ b/redirects.json
@@ -1061,14 +1061,9 @@
       "destination": "/accessibility/patterns/primer-components/links/"
     },
     {
-      "name": "Redirect /guides/accessibility/semantic-html to /accessibility/design-guidance/semantic-html",
-      "match": "^guides/accessibility/semantic-html/?$",
-      "destination": "/accessibility/design-guidance/semantic-html/"
-    },
-    {
-      "name": "Redirect /accessibility/semantic-html to /accessibility/design-guidance/semantic-html",
+      "name": "Redirect /accessibility/semantic-html to /accessibility/design-guidance/semantic-html-and-aria",
       "match": "^accessibility/semantic-html/?$",
-      "destination": "/accessibility/design-guidance/semantic-html/"
+      "destination": "/accessibility/design-guidance/semantic-html-and-aria/"
     },
     {
       "name": "Redirect /guides/accessibility/text-resize-and-respacing to /accessibility/design-guidance/text-resize-and-spacing",
@@ -1119,6 +1114,31 @@
       "name": "Redirect /accessibility/placeholders to /accessibility/patterns/placeholders",
       "match": "^accessibility/placeholders/?$",
       "destination": "/accessibility/patterns/placeholders/"
+    },
+    {
+      "name": "Redirect /contribute to /product/contribute",
+      "match": "^contribute/?$",
+      "destination": "/product/contribute/"
+    },
+    {
+      "name": "Redirect /contribute/design to /product/contribute/design",
+      "match": "^contribute/design/?$",
+      "destination": "/product/contribute/design/"
+    },
+    {
+      "name": "Redirect /contribute/documentation to /product/contribute/documentation",
+      "match": "^contribute/documentation/?$",
+      "destination": "/product/contribute/documentation/"
+    },
+    {
+      "name": "Redirect /contribute/how-to-contribute to /product/contribute/how-to-contribute",
+      "match": "^contribute/how-to-contribute/?$",
+      "destination": "/product/contribute/how-to-contribute/"
+    },
+    {
+      "name": "Redirect /contribute/component-lifecycle to /product/getting-started/component-status",
+      "match": "^contribute/component-lifecycle/?$",
+      "destination": "/product/getting-started/component-status/"
     },
     {
       "name": "Redirect /guides/contribute/how-to-contribute to /product/contribute/how-to-contribute",
@@ -1553,11 +1573,6 @@
       "destination": "https://primer.github.io/brand/{R:1}"
     },
     {
-      "name": "Contribute proxy",
-      "match": "^contribute/(.*)",
-      "destination": "https://primer.github.io/contribute/{R:1}"
-    },
-    {
       "name": "Prism proxy",
       "match": "^prism/(.*)",
       "destination": "https://primer.github.io/prism/{R:1}"
@@ -1571,11 +1586,6 @@
       "name": "React Storybook reverse-proxy",
       "match": "^react/storybook/(.*)",
       "destination": "https://primer.github.io/react/storybook/{R:1}"
-    },
-    {
-      "name": "Octovisuals proxy",
-      "match": "^octovisuals/(.*)",
-      "destination": "https://primer.github.io/octovisuals/{R:1}"
     },
     {
       "name": "Design proxy",

--- a/redirects.json
+++ b/redirects.json
@@ -1593,6 +1593,11 @@
       "destination": "https://primer.github.io/react/storybook/{R:1}"
     },
     {
+      "name": "Octovisuals proxy",
+      "match": "^octovisuals/(.*)",
+      "destination": "https://primer.github.io/octovisuals/{R:1}"
+    },
+    {
       "name": "Design proxy",
       "match": "^/?(.*)",
       "destination": "https://primer-docs-preview.github.com/{R:1}"

--- a/redirects.json
+++ b/redirects.json
@@ -1121,31 +1121,6 @@
       "destination": "/accessibility/patterns/placeholders/"
     },
     {
-      "name": "Redirect /contribute to /product/contribute",
-      "match": "^contribute/?$",
-      "destination": "/product/contribute/"
-    },
-    {
-      "name": "Redirect /contribute/design to /product/contribute/design",
-      "match": "^contribute/design/?$",
-      "destination": "/product/contribute/design/"
-    },
-    {
-      "name": "Redirect /contribute/documentation to /product/contribute/documentation",
-      "match": "^contribute/documentation/?$",
-      "destination": "/product/contribute/documentation/"
-    },
-    {
-      "name": "Redirect /contribute/how-to-contribute to /product/contribute/how-to-contribute",
-      "match": "^contribute/how-to-contribute/?$",
-      "destination": "/product/contribute/how-to-contribute/"
-    },
-    {
-      "name": "Redirect /contribute/component-lifecycle to /product/getting-started/component-status",
-      "match": "^contribute/component-lifecycle/?$",
-      "destination": "/product/getting-started/component-status/"
-    },
-    {
       "name": "Redirect /guides/contribute/how-to-contribute to /product/contribute/how-to-contribute",
       "match": "^guides/contribute/how-to-contribute/?$",
       "destination": "/product/contribute/how-to-contribute/"
@@ -1576,6 +1551,11 @@
       "name": "Brand proxy",
       "match": "^brand/(.*)",
       "destination": "https://primer.github.io/brand/{R:1}"
+    },
+    {
+      "name": "Contribute proxy",
+      "match": "^contribute/(.*)",
+      "destination": "https://primer.github.io/contribute/{R:1}"
     },
     {
       "name": "Prism proxy",

--- a/redirects.json
+++ b/redirects.json
@@ -1553,11 +1553,6 @@
       "destination": "https://primer.github.io/brand/{R:1}"
     },
     {
-      "name": "Contribute proxy",
-      "match": "^contribute/(.*)",
-      "destination": "https://primer.github.io/contribute/{R:1}"
-    },
-    {
       "name": "Prism proxy",
       "match": "^prism/(.*)",
       "destination": "https://primer.github.io/prism/{R:1}"

--- a/redirects.json
+++ b/redirects.json
@@ -1061,6 +1061,11 @@
       "destination": "/accessibility/patterns/primer-components/links/"
     },
     {
+      "name": "Redirect /guides/accessibility/semantic-html to /accessibility/design-guidance/semantic-html-and-aria",
+      "match": "^guides/accessibility/semantic-html/?$",
+      "destination": "/accessibility/design-guidance/semantic-html-and-aria/"
+    },
+    {
       "name": "Redirect /accessibility/semantic-html to /accessibility/design-guidance/semantic-html-and-aria",
       "match": "^accessibility/semantic-html/?$",
       "destination": "/accessibility/design-guidance/semantic-html-and-aria/"


### PR DESCRIPTION
## What changed

Updates `redirects.json` to reflect the latest changes from `rules.ts` in <a href="https://github.com/github/primer-docs">github/primer-docs</a>, so we get the changes described in https://github.com/github/primer-docs/issues/1087 live on the site. Also removes the Contribute proxy so we can control those rules in Next.js instead (https://github.com/github/primer-docs/pull/1099).

### Changes
- Update `/accessibility/semantic-html` redirect destination to `semantic-html-and-aria` (from a previous change that was never generated)
- Re-add `/guides/accessibility/semantic-html` redirect to `semantic-html-and-aria` destination to preserve the legacy path
- Remove the Contribute proxy

## Next steps
- [x] Deploy to staging (`staging` branch) and verify via `script/validate --url 'https://primerstyle-staging.azurewebsites.net'`
- [x] Get a review. Reviewer should visit the updated staging site at https://primerstyle-staging.azurewebsites.net and run through the following redirects:
   - [x] /guides/accessibility/semantic-html → should redirect to /accessibility/design-guidance/semantic-html-and-aria/ (newly added)
   - [x] /accessibility/semantic-html → same destination (pre-existing)
   - [x] /octovisuals/* → https://primer.github.io/octovisuals/* (Octovisuals proxy, retained)
   - [x] /contribute goes to /product/contribute
   - [x] /contribute/design goes to /product/contribute/design
   - [x] /contribute/documentation goes to /product/contribute/documentation
   - [x] /contribute/how-to-contribute goes to /product/contribute/how-to-contribute
   - [x] /contribute/component-lifecycle goes to /product/getting-started/component-status
- [x] Merge and run validate against production